### PR TITLE
Update player.putIntoPlay

### DIFF
--- a/server/game/deck.js
+++ b/server/game/deck.js
@@ -57,7 +57,10 @@ class Deck {
         });
 
         result.allCards = result.provinceCards.concat(result.conflictCards).concat(result.dynastyCards);
-        result.allCards.push(result.stronghold);
+
+        if(result.stronghold) {
+            result.allCards.push(result.stronghold);
+        }
 
         return result;
     }

--- a/server/game/dynastycardaction.js
+++ b/server/game/dynastycardaction.js
@@ -17,7 +17,7 @@ class DynastyCardAction extends BaseAbility {
 
         return (
             game.currentPhase === 'dynasty' &&
-            source.canBeDynastyed() &&
+            source.isDynasty &&
             source.getType() !== 'event' &&
             player.isCardInPlayableLocation(source, 'dynasty') &&
             player.canPutIntoPlay(source)

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -50,7 +50,13 @@ class Player extends Spectator {
         this.conflicts = new ConflictTracker();
         this.minReserve = 0;
         this.costReducers = [];
-        this.playableLocations = _.map(['dynasty', 'play'], playingType => new PlayableLocation(playingType, this, 'hand'));
+        this.playableLocations = [
+            new PlayableLocation('play', this, 'hand'),
+            new PlayableLocation('dynasty', this, 'province 1'),
+            new PlayableLocation('dynasty', this, 'province 2'),
+            new PlayableLocation('dynasty', this, 'province 3'),
+            new PlayableLocation('dynasty', this, 'province 4')
+        ];
         this.cannotGainConflictBonus = false;
         this.cannotTriggerCardAbilities = false;
         this.promptedActionWindows = user.promptedActionWindows || {

--- a/test/server/card/drawcard.hasKeyword.spec.js
+++ b/test/server/card/drawcard.hasKeyword.spec.js
@@ -1,6 +1,6 @@
 const DrawCard = require('../../../server/game/drawcard.js');
 
-xdescribe('the DrawCard', function() {
+describe('the DrawCard', function() {
     describe('the hasKeyword() function', function() {
         beforeEach(function() {
             this.owner = {};
@@ -53,7 +53,7 @@ xdescribe('the DrawCard', function() {
             this.game.playersAndSpectators['bar'] = this.player2;
             this.game.initialise();
 
-            this.game.currentPhase = 'dyansty';
+            this.game.currentPhase = 'dynasty';
             this.player.phase = 'dynasty';
         });
 
@@ -75,9 +75,9 @@ xdescribe('the DrawCard', function() {
 
             describe('when the card has a keyword line', function() {
                 beforeEach(function() {
-                    this.card = new DrawCard(this.player, { type: 'attachment', cost: 0, text: 'covert. Restricted. Notarealkeyword.\n Extra text because we need stuff here.' });
-                    this.card.location = 'hand';
-                    this.player.hand = _([this.card]);
+                    this.card = new DrawCard(this.player, { type: 'character', cost: 0, side: 'dynasty', text: 'covert. Restricted. Notarealkeyword.\n Extra text because we need stuff here.' });
+                    this.card.location = 'province 1';
+                    this.player.provinceOne = _([this.card]);
                     this.player.playCard(this.card);
                     // Resolve events in pipeline.
                     this.game.continue();
@@ -98,7 +98,7 @@ xdescribe('the DrawCard', function() {
                     // Resolve events in pipeline.
                     this.game.continue();
                     expect(this.card.hasKeyword('covert')).toBe(false);
-                    expect(this.card.hasKeyword('Restricted')).toBe(true);
+                    expect(this.card.hasKeyword('Restricted')).toBe(false);
                     expect(this.card.hasKeyword('Sincerity')).toBe(true);
                 });
             });

--- a/test/server/dynastycardaction.spec.js
+++ b/test/server/dynastycardaction.spec.js
@@ -4,8 +4,8 @@ describe('DynastyCardAction', function () {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'on', 'removeListener']);
         this.playerSpy = jasmine.createSpyObj('player', ['canPutIntoPlay', 'isCardInPlayableLocation', 'putIntoPlay']);
-        this.cardSpy = jasmine.createSpyObj('card', ['canBeDynastyed', 'getType']);
-        this.cardSpy.canBeDynastyed.and.returnValue(true);
+        this.cardSpy = jasmine.createSpyObj('card', ['getType']);
+        this.cardSpy.isDynasty = true;
         this.cardSpy.controller = this.playerSpy;
         this.cardSpy.owner = this.playerSpy;
         this.context = {
@@ -63,7 +63,7 @@ describe('DynastyCardAction', function () {
 
         describe('when the card is forbidden from being played in dynasty', function() {
             beforeEach(function() {
-                this.cardSpy.canBeDynastyed.and.returnValue(false);
+                this.cardSpy.isDynasty = false;
             });
 
             it('should return false', function() {

--- a/test/server/player/putintoplay.spec.js
+++ b/test/server/player/putintoplay.spec.js
@@ -2,39 +2,43 @@ const _ = require('underscore');
 
 const Player = require('../../../server/game/player.js');
 
-xdescribe('Player', function() {
+describe('Player', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['queueStep', 'raiseEvent', 'playerDecked']);
+        this.gameSpy = jasmine.createSpyObj('game', ['queueStep', 'raiseEvent', 'playerDecked', 'getPlayers']);
         this.player = new Player('1', 'Player 1', true, this.gameSpy);
         this.player.initialise();
 
-        spyOn(this.player, 'getDuplicateInPlay');
-
-        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isBestow', 'play', 'moveTo']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'moveTo', 'isUnique', 'applyPersistentEffects']);
         this.cardSpy.controller = this.player;
         this.cardSpy.owner = this.player;
-        this.dupeCardSpy = jasmine.createSpyObj('dupecard', ['addDuplicate']);
         this.player.hand.push(this.cardSpy);
         this.cardSpy.location = 'hand';
+        this.player.allCards.push(this.cardSpy);
+
+        this.cardSpy.isUnique.and.returnValue(true);
+        this.cardSpy.name = 'foo';
+        this.existingCard = {
+            location: 'play area',
+            name: 'foo',
+            controller: this.player,
+            owner: this.player
+        };
+
+        this.opponent = new Player('2', 'Player 2', true, this.gameSpy);
+        this.opponent.initialise();
+        this.gameSpy.getPlayers.and.returnValue([this.player, this.opponent]);
     });
 
     describe('canPutIntoPlay()', function() {
-        beforeEach(function() {
-            this.ownerSpy = jasmine.createSpyObj('ownerPlayer', ['canResurrect', 'getDuplicateInPlay', 'isCharacterDead']);
-        });
 
         describe('when the player is the owner of the card', function() {
-            beforeEach(function() {
-                this.cardSpy.owner = this.player;
-            });
-
             describe('and the character is already in play', function() {
                 beforeEach(function() {
-                    this.player.getDuplicateInPlay.and.returnValue({ foo: 'bar' });
+                    this.player.allCards.push(this.existingCard);
                 });
 
-                it('should return true', function() {
-                    expect(this.player.canPutIntoPlay(this.cardSpy)).toBe(true);
+                it('should return false', function() {
+                    expect(this.player.canPutIntoPlay(this.cardSpy)).toBe(false);
                 });
             });
 
@@ -42,12 +46,12 @@ xdescribe('Player', function() {
 
         describe('when the player is not the owner of the card', function() {
             beforeEach(function() {
-                this.cardSpy.owner = this.ownerSpy;
+                this.cardSpy.owner = this.opponent;
             });
 
             describe('and the character is already in play', function() {
                 beforeEach(function() {
-                    this.player.getDuplicateInPlay.and.returnValue({ foo: 'bar' });
+                    this.player.allCards.push(this.existingCard);
                 });
 
                 it('should return false', function() {
@@ -57,7 +61,9 @@ xdescribe('Player', function() {
 
             describe('and the character is in play for the owner', function() {
                 beforeEach(function() {
-                    this.ownerSpy.getDuplicateInPlay.and.returnValue({ foo: 'bar' });
+                    this.opponent.allCards.push(this.existingCard);
+                    this.existingCard.owner = this.opponent;
+                    this.existingCard.controller = this.opponent;
                 });
 
                 it('should return false', function() {
@@ -69,77 +75,37 @@ xdescribe('Player', function() {
     });
 
     describe('putIntoPlay', function() {
-        describe('when the playing type is marshal', function() {
+        describe('when the playing type is dynasty', function() {
             describe('and the card is not a duplicate', function() {
                 beforeEach(function() {
-                    this.player.getDuplicateInPlay.and.returnValue(null);
-                    this.player.putIntoPlay(this.cardSpy, 'marshal');
+                    this.player.putIntoPlay(this.cardSpy, 'dynasty');
                 });
 
                 it('should add the card to cards in play', function() {
                     expect(this.player.cardsInPlay).toContain(this.cardSpy);
                 });
 
-                it('should be placed face up', function() {
-                    expect(this.cardSpy.facedown).toBe(false);
-                });
-
                 it('should be marked as new', function() {
                     expect(this.cardSpy.new).toBe(true);
                 });
 
-                it('should play the card as non-ambush', function() {
-                    expect(this.cardSpy.play).toHaveBeenCalledWith(this.player, false);
-                });
-
                 it('should raise the onCardEntersPlay event', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardEntersPlay', jasmine.objectContaining({ card: this.cardSpy, playingType: 'marshal' }));
-                });
-
-                describe('when it has the Bestow keyword', function() {
-                    beforeEach(function() {
-                        this.cardSpy.isBestow.and.returnValue(true);
-                        this.player.putIntoPlay(this.cardSpy, 'marshal');
-                    });
-
-                    it('should queue the bestow prompt', function() {
-                        expect(this.gameSpy.queueStep).toHaveBeenCalled();
-                        expect(this.gameSpy.queueStep.calls.mostRecent().args[0].constructor.name).toBe('BestowPrompt');
-                    });
+                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardEntersPlay', jasmine.objectContaining({ card: this.cardSpy, playingType: 'dynasty' }));
                 });
             });
 
             describe('and the card is a duplicate', function() {
                 beforeEach(function() {
-                    this.player.getDuplicateInPlay.and.returnValue(this.dupeCardSpy);
-                    this.player.putIntoPlay(this.cardSpy, 'marshal');
+                    this.player.allCards.push(this.existingCard);
+                    this.player.putIntoPlay(this.cardSpy, 'dynasty');
                 });
 
                 it('should not add the card to cards in play', function() {
                     expect(this.player.cardsInPlay).not.toContain(this.cardSpy);
                 });
 
-                it('should not play the card as an ambush', function() {
-                    expect(this.cardSpy.play).not.toHaveBeenCalled();
-                });
-
                 it('should not raise the onCardEntersPlay event', function() {
                     expect(this.gameSpy.raiseEvent).not.toHaveBeenCalledWith('onCardEntersPlay', jasmine.objectContaining({ card: this.cardSpy }));
-                });
-
-                it('should add as a duplicate', function() {
-                    expect(this.dupeCardSpy.addDuplicate).toHaveBeenCalledWith(this.cardSpy);
-                });
-
-                describe('when it has the Bestow keyword', function() {
-                    beforeEach(function() {
-                        this.cardSpy.isBestow.and.returnValue(true);
-                        this.player.putIntoPlay(this.cardSpy, 'marshal');
-                    });
-
-                    it('should not queue the bestow prompt', function() {
-                        expect(this.gameSpy.queueStep).not.toHaveBeenCalled();
-                    });
                 });
             });
         });
@@ -153,8 +119,7 @@ xdescribe('Player', function() {
 
             describe('and there is no duplicate out', function() {
                 beforeEach(function() {
-                    this.player.getDuplicateInPlay.and.returnValue(null);
-                    this.player.putIntoPlay(this.cardSpy, 'marshal');
+                    this.player.putIntoPlay(this.cardSpy, 'play');
                 });
 
                 it('should prompt for attachment target', function() {
@@ -168,20 +133,16 @@ xdescribe('Player', function() {
 
             describe('and there is a duplicate out', function() {
                 beforeEach(function() {
-                    this.player.getDuplicateInPlay.and.returnValue(this.dupeCardSpy);
-                    this.player.putIntoPlay(this.cardSpy, 'marshal');
+                    this.player.allCards.push(this.existingCard);
+                    this.player.putIntoPlay(this.cardSpy, 'dynasty');
                 });
 
                 it('should not prompt for attachment target', function() {
                     expect(this.player.promptForAttachment).not.toHaveBeenCalled();
                 });
 
-                it('should remove the card from hand', function() {
-                    expect(this.player.hand).not.toContain(this.cardSpy);
-                });
-
-                it('should add a duplicate to the existing card in play', function() {
-                    expect(this.dupeCardSpy.addDuplicate).toHaveBeenCalledWith(this.cardSpy);
+                it('should not remove the card from hand', function() {
+                    expect(this.player.hand).toContain(this.cardSpy);
                 });
 
                 it('should not add a new card to play', function() {
@@ -190,71 +151,14 @@ xdescribe('Player', function() {
             });
         });
 
-        describe('when the playing type is ambush', function() {
-            describe('and the card is not a duplicate', function() {
-                beforeEach(function() {
-                    this.player.getDuplicateInPlay.and.returnValue(null);
-                    this.player.putIntoPlay(this.cardSpy, 'ambush');
-                });
-
-                it('should add the card to cards in play', function() {
-                    expect(this.player.cardsInPlay).toContain(this.cardSpy);
-                });
-
-                it('should be placed face up', function() {
-                    expect(this.cardSpy.facedown).toBe(false);
-                });
-
-                it('should be marked as new', function() {
-                    expect(this.cardSpy.new).toBe(true);
-                });
-
-                it('should play the card as an ambush', function() {
-                    expect(this.cardSpy.play).toHaveBeenCalledWith(this.player, true);
-                });
-
-                it('should raise the onCardEntersPlay event', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardEntersPlay', jasmine.objectContaining({ card: this.cardSpy, playingType: 'ambush' }));
-                });
-            });
-
-            describe('and the card is a duplicate', function() {
-                beforeEach(function() {
-                    this.player.getDuplicateInPlay.and.returnValue(this.dupeCardSpy);
-                    this.player.putIntoPlay(this.cardSpy, 'ambush');
-                });
-
-                it('should not add the card to cards in play', function() {
-                    expect(this.player.cardsInPlay).not.toContain(this.cardSpy);
-                });
-
-                it('should not play the card as an ambush', function() {
-                    expect(this.cardSpy.play).not.toHaveBeenCalled();
-                });
-
-                it('should not raise the onCardEntersPlay event', function() {
-                    expect(this.gameSpy.raiseEvent).not.toHaveBeenCalledWith('onCardEntersPlay', jasmine.objectContaining({ card: this.cardSpy }));
-                });
-
-                it('should add as a duplicate', function() {
-                    expect(this.dupeCardSpy.addDuplicate).toHaveBeenCalledWith(this.cardSpy);
-                });
-            });
-        });
-
         describe('when the card is not controlled by the player', function() {
             beforeEach(function() {
-                this.opponent = new Player('2', 'Player 2', true, this.gameSpy);
-                this.opponent.initialise();
-                spyOn(this.opponent, 'getDuplicateInPlay');
-                spyOn(this.opponent, 'isCharacterDead');
-                spyOn(this.opponent, 'canResurrect');
                 this.cardSpy.controller = this.opponent;
                 this.cardSpy.owner = this.opponent;
                 this.opponent.hand.push(this.cardSpy);
                 this.player.hand = _([]);
 
-                this.player.putIntoPlay(this.cardSpy, 'marshal');
+                this.player.putIntoPlay(this.cardSpy, 'play');
             });
 
             it('should add the card to cards in play', function() {


### PR DESCRIPTION
Some pretty big changes to this function.

- Satisfy unique restrictions on playing. I've assumed _"unique"_ in L5R will use the same constraints in place via FAQs for thrones.
- Remove thrones-specific putIntoPlay details.
  - No more playing cards as dupes
  - No bestow
  - No special handling for the setup phase

I'm not sure what `card.new` is for - I'm assuming that it was part of Thrones' setup phase, but left it in just in case.