### PR TITLE
Conflict Phase Framework Events

### DIFF
--- a/server/game/conflicttracker.js
+++ b/server/game/conflicttracker.js
@@ -3,6 +3,7 @@ const _ = require('underscore');
 class ConflictTracker {
     constructor() {
         this.complete = 0;
+        this.conflictOpportunities = 2;
         this.conflictTypes = {
             military: {
                 performed: 0,
@@ -60,6 +61,7 @@ class ConflictTracker {
     }
 
     reset() {
+        this.conflictOpportunities = 2;
         this.complete = 0;
         this.resetForType('military');
         this.resetForType('political');
@@ -132,6 +134,10 @@ class ConflictTracker {
 
     modifyMaxForType(conflictType, number) {
         this.conflictTypes[conflictType].max += number;
+    }
+    
+    usedConflictOpportunity() {
+        this.conflictOpportunities--;
     }
 }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -44,6 +44,8 @@ class Player extends Spectator {
         this.drawBid = 0;
         this.duelBid = 0;
         this.showBid = 0;
+        this.imperialFavor = '';
+        this.totalGloryForFavor = 0;
 
 
         this.deck = {};
@@ -318,7 +320,8 @@ class Player extends Spectator {
     }
 
     canInitiateConflict(conflictType) {
-        return !this.conflicts.isAtMax(conflictType);
+        return (!this.conflicts.isAtMax(conflictType) && 
+                this.conflicts.conflictOpportunitiesRemaining > 0);
     }
 
     canSelectAsFirstPlayer(player) {
@@ -894,7 +897,7 @@ class Player extends Spectator {
     getFavor() {
         var cardGlory = this.cardsInPlay.reduce((memo, card) => {
             if(!card.bowed && card.getType() === 'character' && card.contributesToFavor) {
-                return memo + card.getGlory();
+                return memo + card.glory;
             }
 
             return memo;
@@ -903,8 +906,24 @@ class Player extends Spectator {
         this.cardsInPlay.each(card => {
             cardGlory = card.modifyFavor(this, cardGlory);
         });
+        
+        let rings = this.getClaimedRings();
+        
+        this.totalGloryForFavor = cardGlory + _.size(rings);
 
-        return cardGlory;
+        return this.totalGloryForFavor;
+    }
+
+    getClaimedRings() {
+        return _.filter(this.game.rings, ring => ring.claimedby === this.name);
+    }
+ 
+    claimImperialFavor(conflictType) {
+        this.imperialFavor = conflictType;
+    }
+
+    loseImperialFavor() {
+        this.imperialFavor = '';
     }
 
     readyCards(notCharacters = false) {


### PR DESCRIPTION
These additions implement the missing framework events for the Conflict Phase.

Changed files:
conflicttracker.js: We need some way of tracking how many conflicts have been initiated or passed by a player.  We can't count won, lost, or performed conflicts because when a conflict opportunity is passed it doesn't count as any of those.
conflictphase.js: I added the remaining framework steps once conflicts have been completed, and tidied up the current code a bit so the phase progresses through the conflict declaration steps.  I also implemented a new way of changing players, as the conflict phase doesn't necessarily go back and forth from one player to the other (due to cards like e.g. Breakthrough)
player.js: I added functions and variables for tracking Imperial Favor
