### PR TITLE
Conflict Framework Steps

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -29,7 +29,7 @@ class DrawCard extends BaseCard {
         this.isHonored = false;
         this.isDishonored = false;
         this.readysDuringReadying = true;
-        this.challengeOptions = {
+        this.conflictOptions = {
             doesNotBowAs: {
                 attacker: false,
                 defender: false
@@ -264,26 +264,26 @@ class DrawCard extends BaseCard {
         this.inConflict = false;
     }
 
-    canDeclareAsAttacker(challengeType) {
-        return this.allowGameAction('declareAsAttacker') && this.canDeclareAsParticipant(challengeType);
+    canDeclareAsAttacker(conflictType) {
+        return this.allowGameAction('declareAsAttacker') && this.canDeclareAsParticipant(conflictType);
     }
 
-    canDeclareAsDefender(challengeType) {
-        return this.allowGameAction('declareAsDefender') && this.canDeclareAsParticipant(challengeType);
+    canDeclareAsDefender(conflictType) {
+        return this.allowGameAction('declareAsDefender') && this.canDeclareAsParticipant(conflictType);
     }
 
-    canDeclareAsParticipant(challengeType) {
+    canDeclareAsParticipant(conflictType) {
         return (
-            this.canParticipateInChallenge() &&
+            this.canParticipateInConflict() &&
             this.location === 'play area' &&
             !this.stealth &&
-            (!this.bowed || this.challengeOptions.canBeDeclaredWhileBowing) &&
-            (this.hasIcon(challengeType) || this.challengeOptions.canBeDeclaredWithoutIcon)
+            (!this.bowed || this.conflictOptions.canBeDeclaredWhileBowing) &&
+            (this.hasIcon(conflictType) || this.conflictOptions.canBeDeclaredWithoutIcon)
         );
     }
 
     canParticipateInConflict() {
-        return this.allowGameAction('participateInChallenge');
+        return this.allowGameAction('participateInConflict');
     }
 
     canBeKilled() {
@@ -294,6 +294,13 @@ class DrawCard extends BaseCard {
         return this.allowGameAction('play');
     }
 
+    returnHomeFromConflict(side) {
+        if(!this.card.conflictOptions.doesNotBowAs[side] && !this.bowed) {
+            this.controller.bowCard(this);
+        }
+        this.inConflict = false;
+    }
+ 
     getSummary(activePlayer, hideWhenFaceup) {
         let baseSummary = super.getSummary(activePlayer, hideWhenFaceup);
 

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -119,7 +119,6 @@ class ConflictFlow extends BaseStep {
 
     announceDefenderSkill() {
         // Explicitly recalculate strength in case an effect has modified character strength.
-        _.each(this.conflict.defenders, card => card.inConflict = true);
         this.conflict.calculateSkill();
         if(this.conflict.defenders.length > 0) {
             this.game.addMessage('{0} has defended with skill {1}', this.conflict.defendingPlayer, this.conflict.defenderSkill);

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -120,10 +120,10 @@ class ConflictFlow extends BaseStep {
     announceDefenderSkill() {
         // Explicitly recalculate strength in case an effect has modified character strength.
         this.conflict.calculateSkill();
-        if(this.conflict.defenders.length > 0) {
-            this.game.addMessage('{0} has defended with skill {1}', this.conflict.defendingPlayer, this.conflict.defenderSkill);
-        } else {
+        if(this.conflict.defenders === []) {
             this.game.addMessage('{0} does not defend the conflict', this.conflict.defendingPlayer);
+        } else {
+            this.game.addMessage('{0} has defended with skill {1}', this.conflict.defendingPlayer, this.conflict.defenderSkill);
         }
     }
 

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -30,10 +30,15 @@ class ConflictFlow extends BaseStep {
             //Reveal province
             new SimpleStep(this.game, () => this.announceAttackerSkill()),
             new SimpleStep(this.game, () => this.promptForDefenders()),
-            new SimpleStep(this.game, () => this.announceDefenderSskill()),
+            new SimpleStep(this.game, () => this.announceDefenderSkill()),
             new ActionWindow(this.game, 'Conflict Action Window', 'conflictAction'),
             new SimpleStep(this.game, () => this.determineWinner()),
-            new SimpleStep(this.game, () => this.applyKeywords()),
+            //new SimpleStep(this.game, () => this.applyKeywords()),
+            new SimpleStep(this.game, () => this.applyUnopposed()),
+            //Check for Province Break
+            new SimpleStep(this.game, () => this.resolveRingEffects()),
+            new SimpleStep(this.game, () => this.claimRing()),
+            new SimpleStep(this.game, () => this.returnHome()),
             new SimpleStep(this.game, () => this.completeConflict())
         ]);
     }
@@ -75,8 +80,8 @@ class ConflictFlow extends BaseStep {
 
     announceAttackerSkill() {
         // Explicitly recalculate strength in case an effect has modified character strength.
-        this.conflict.calculateStrength();
-        this.game.addMessage('{0} has initiated a {1} conflict with strength {2}', this.conflict.attackingPlayer, this.conflict.conflictType, this.conflict.attackerStrength);
+        this.conflict.calculateSkill();
+        this.game.addMessage('{0} has initiated a {1} conflict with skill {2}', this.conflict.attackingPlayer, this.conflict.conflictType, this.conflict.attackerSkill);
     }
 
     promptForDefenders() {
@@ -114,9 +119,10 @@ class ConflictFlow extends BaseStep {
 
     announceDefenderSkill() {
         // Explicitly recalculate strength in case an effect has modified character strength.
-        this.conflict.calculateStrength();
-        if(this.conflict.defenderStrength > 0) {
-            this.game.addMessage('{0} has defended with strength {1}', this.conflict.defendingPlayer, this.conflict.defenderStrength);
+        _.each(this.conflict.defenders, card => card.inConflict = true);
+        this.conflict.calculateSkill();
+        if(this.conflict.defenders.length > 0) {
+            this.game.addMessage('{0} has defended with skill {1}', this.conflict.defendingPlayer, this.conflict.defenderSkill);
         } else {
             this.game.addMessage('{0} does not defend the conflict', this.conflict.defendingPlayer);
         }
@@ -126,18 +132,15 @@ class ConflictFlow extends BaseStep {
         this.conflict.determineWinner();
 
         if(!this.conflict.winner && !this.conflict.loser) {
-            this.game.addMessage(this.conflict.noWinnerMessage);
+            this.game.addMessage('There is no winner or loser for this conflict because both sides have 0 skill');
         } else {
             this.game.addMessage('{0} won a {1} conflict {2} vs {3}',
-                this.conflict.winner, this.conflict.conflictType, this.conflict.winnerStrength, this.conflict.loserStrength);
+                this.conflict.winner, this.conflict.conflictType, this.conflict.winnerSkill, this.conflict.loserSkill);
+            this.conflict.winner.conflicts.won(this.conflict.conflictType, this.conflict.winner === this.conflict.attackingPlayer);
+            this.conflict.loser.conflicts.lost(this.conflict.conflictType, this.conflict.loser === this.conflict.attackingPlayer);
         }
 
         this.game.raiseEvent('afterConflict', this.conflict);
-
-        // Only open a winner action window if a winner / loser was determined.
-        if(this.conflict.winner) {
-            this.game.queueStep(new ActionWindow(this.game, 'After winner determined', 'winnerDetermined'));
-        }
     }
 
     applyKeywords() {
@@ -148,6 +151,70 @@ class ConflictFlow extends BaseStep {
         });
     }
 
+    applyUnopposed() {
+        if(this.conflict.cancelled) {
+            return;
+        }
+
+        if(this.conflict.winner === this.conflict.attackingPlayer && this.conflict.defenders.length === 0) {
+            this.game.addHonor(this.conflict.loser, -1);
+        }
+    }
+    
+    resolveRingEffects() {
+        if(this.conflict.cancelled) {
+            return;
+        }
+
+        if(this.conflict.isAttackerTheWinner()) {
+            let menuTitle = 'Do you want to resolve the ' + this.conflict.conflictRing + ' ring?';
+            let waitingPromptTitle = 'Waiting for opponent to use decide whether to resolve the ' + this.conflict.conflictRing + ' ring';
+            this.game.promptWithMenu(this.conflict.winner, this, {
+                activePrompt: {
+                    promptTitle: 'Resolve Ring',
+                    menuTitle: menuTitle,
+                    buttons: [
+                        { text: 'Yes', arg: 'Yes', method: 'triggerRingResolutionEvent' },
+                        { text: 'No', arg: 'No', method: 'triggerRingResolutionEvent' }
+                    ]
+                },
+                waitingPromptTitle: waitingPromptTitle
+            });
+        }       
+    }
+    
+    triggerRingResolutionEvent(player, arg) {
+        if(arg !== 'No') {
+            this.game.raiseEvent('onResolveRingEffects', this.conflict, () => {
+                player.resolveRingEffects(this.conflict.conflictRing);
+            });
+        }
+        return true;
+    }
+    
+    claimRing() {
+        if(this.conflict.cancelled) {
+            return;
+        }
+
+        if(this.conflict.winner) {
+            let ring = _.find(this.game.rings, ring => {
+                return ring.element === this.conflict.conflictRing;
+            });
+            this.game.raiseEvent('onClaimRing', this.conflict, ring.claimRing(this.conflict.winner));
+        }
+    }
+
+    returnHome() {
+        if(this.conflict.cancelled) {
+            return;
+        }
+
+        this.game.raiseEvent('onReturnHome', this.conflict);
+        _.each(this.conflict.attackers, card => card.returnHomeFromConflict('attacker'));
+        _.each(this.conflict.defenders, card => card.returnHomeFromConflict('defender'));
+    }
+    
     completeConflict() {
         this.game.raiseEvent('onConflictFinished', this.conflict);
 

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -155,7 +155,7 @@ class ConflictFlow extends BaseStep {
             return;
         }
 
-        if(this.conflict.winner === this.conflict.attackingPlayer && this.conflict.defenders.length === 0) {
+        if(this.conflict.winner === this.conflict.attackingPlayer && this.conflict.defenders === []) {
             this.game.addHonor(this.conflict.loser, -1);
         }
     }

--- a/server/game/ring.js
+++ b/server/game/ring.js
@@ -44,7 +44,7 @@ class Ring {
 
     claimRing(player) {
         this.claimed = true;
-        this.claimedBy = player;
+        this.claimedBy = player.name;
     }
 
     resetRing() {


### PR DESCRIPTION
This change implements the remaining framework steps for conflicts

Files Changed:
drawcard.js: Mostly changing outdated names from challenge to conflict. Added a function to return units home after a conflict
conflictflow.js: again, changing challenge to conflict and strength to skill. Added the framework steps after winner is determined. NB: there are no ring effects in this PR
ring.js: ring.claimedBy is displayed on the gameboard, so it needs to be a string.