### PR TITLE
duplicate unique action

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -4,10 +4,12 @@ const BaseCard = require('./basecard.js');
 const SetupCardAction = require('./setupcardaction.js');
 const DynastyCardAction = require('./dynastycardaction.js');
 const PlayCardAction = require('./playcardaction.js');
+const DuplicateUniqueAction = require('./duplicateuniqueaction.js');
 
 const StandardPlayActions = [
     new SetupCardAction(),
     new DynastyCardAction(),
+    new DuplicateUniqueAction(),
     new PlayCardAction()
 ];
 

--- a/server/game/duplicateuniqueaction.js
+++ b/server/game/duplicateuniqueaction.js
@@ -1,0 +1,43 @@
+const BaseAbility = require('./baseability.js');
+
+class DuplicateUniqueAction extends BaseAbility {
+    constructor() {
+        super([]);
+        this.title = 'DuplicateUniqueAction';
+    }
+
+    meetsRequirements(context) {
+        var {game, player, source} = context;
+
+        return (
+            game.currentPhase === 'dynasty' &&
+            !source.facedown &&
+            source.getType() === 'character' &&
+            (player.isCardInPlayableLocation(context.source, 'dynasty') || player.isCardInPlayableLocation(context.source, 'hand')) &&
+            !player.canPutIntoPlay(source) &&
+            game.currentActionWindow &&
+            game.currentActionWindow.currentPlayer === player &&
+            game.abilityCardStack.length === 1
+        );
+    }
+    
+    executeHandler(context) {
+        let duplicate = context.player.getDuplicateInPlay(context.source);
+        duplicate.modifyFate(1);
+        
+        let location = context.source.location;
+        context.player.discardCard(context.source);
+        if(['province 1', 'province 2', 'province 3', 'province 4'].includes(location)) {
+            context.player.moveCard(context.player.dynastyDeck.first(), location);
+        }
+        
+        context.game.addMessage('{0} discards a duplicate to add 1 fate to {1}', context.player, context.source.name);
+    }
+
+    isCardAbility() {
+        return false;
+    }
+}
+
+module.exports = DuplicateUniqueAction;
+


### PR DESCRIPTION
Players should be able to discard duplicates during the dynasty phase in order to add fate to a unique card.