### PR TITLE
Reset drawbid so players can choose every round

### DIFF
--- a/less/cards.less
+++ b/less/cards.less
@@ -72,7 +72,7 @@
     box-shadow: 0 0 1px 2px @brand-warning;
   }
 
-  &.challenge {
+  &.conflict {
     box-shadow: 0 0 1px 2px @brand-danger;
   }
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -314,6 +314,10 @@ class DrawCard extends BaseCard {
         }
         this.inConflict = false;
     }
+    
+    play() {
+    //empty function so playcardaction doesn't crash the game
+    }
  
     getSummary(activePlayer, hideWhenFaceup) {
         let baseSummary = super.getSummary(activePlayer, hideWhenFaceup);

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -194,7 +194,7 @@ class Game extends EventEmitter {
         }
 
         // Attempt to play cards that are not already in the play area.
-        if(['hand', 'province 1', 'province 2', 'province 3', 'province 4'].includes(card.location) && player.playCard(card)) {
+        if(['hand', 'province 1', 'province 2', 'province 3', 'province 4'].includes(card.location) && card.getType() !== 'province' && player.playCard(card)) {
             return;
         }
 

--- a/server/game/playcardaction.js
+++ b/server/game/playcardaction.js
@@ -22,7 +22,7 @@ class PlayCardAction extends BaseAbility {
 
     executeHandler(context) {
         context.game.addMessage('{0} plays {1} costing {2}', context.player, context.source, context.costs.gold);
-        //context.source.play(context.player);
+        context.source.play(context.player);
     }
 
     isPlayableEventAbility() {

--- a/server/game/playcardaction.js
+++ b/server/game/playcardaction.js
@@ -22,7 +22,7 @@ class PlayCardAction extends BaseAbility {
 
     executeHandler(context) {
         context.game.addMessage('{0} plays {1} costing {2}', context.player, context.source, context.costs.gold);
-        context.source.play(context.player);
+        //context.source.play(context.player);
     }
 
     isPlayableEventAbility() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -46,7 +46,6 @@ class Player extends Spectator {
         this.showBid = 0;
         this.imperialFavor = '';
         this.totalGloryForFavor = 0;
-        this.passedDynasty = false;
 
 
         this.deck = {};
@@ -608,6 +607,7 @@ class Player extends Spectator {
         this.game.raiseEvent('onIncomeCollected', { player: this });
 
         this.passedDynasty = false;
+        this.drawBid = 0;
         this.limitedPlayed = 0;
     }
 


### PR DESCRIPTION
drawBid needs reseting to 0 at the start of each round so players can choose a different value in the Draw phase