### PR TITLE
Add Fate placement to cards played during Dynasty

### DIFF
--- a/client/About.jsx
+++ b/client/About.jsx
@@ -34,16 +34,6 @@ class About extends React.Component {
                 much information as possible, including what the problem is, what you were expecting, what you did leading up to it, and if possible include a screenshot.  We are a very small
                 development team and if bugs are not reported, it is unlikely they will get fixed.</p>
 
-                <h3>Manual Mode</h3>    
-                <p>At this stage in development, it is recommended that you make use of manual mode.  As cards are not yet implemented, the game is not able to 
-                correctly determine who will win conflicts, as you will probably make use of card abilities during the combat which will change skill levels, 
-                or add or remove participants from the conflict.  In addition, you may want to use an as-yet-unimplemented ability during an action window, 
-                and the game isn't currently able to recognise them.</p>  
-                <p>Manual mode means that instead of attempting to resolve conflicts automatically, the attacking player will be asked to indicate who won
-                the conflict.  It also means that during action windows, there is an additional 'Manual Action' button available to you.  Use this when you
-                want to use a non implemented card action, and the game will know to pass priority to your opponent.</p>
-                <p>You can activate or deactivate manual mode by using the /manual command in chat.</p>
-
                 <h3>Manual Commands</h3>
                 <p>The following manual commands have been implemented in order to allow for a smoother gameplay experience:
                 </p>
@@ -60,7 +50,6 @@ class About extends React.Component {
                     <li>/unclaim-ring ring - Set 'ring' as unclaimed.</li>
                     <li>/honor - Move the state of a character towards honored.</li>
                     <li>/dishonor - Move the state of a character towards dishonored.</li>
-                    <li>/manual - Activate or deactivate manual mode (see above).</li>
                 </ul>
 
                 { /*<h3>Can I help?</h3>

--- a/client/About.jsx
+++ b/client/About.jsx
@@ -34,6 +34,16 @@ class About extends React.Component {
                 much information as possible, including what the problem is, what you were expecting, what you did leading up to it, and if possible include a screenshot.  We are a very small
                 development team and if bugs are not reported, it is unlikely they will get fixed.</p>
 
+                <h3>Manual Mode</h3>    
+                <p>At this stage in development, it is recommended that you make use of manual mode.  As cards are not yet implemented, the game is not able to 
+                correctly determine who will win conflicts, as you will probably make use of card abilities during the combat which will change skill levels, 
+                or add or remove participants from the conflict.  In addition, you may want to use an as-yet-unimplemented ability during an action window, 
+                and the game isn't currently able to recognise them.</p>  
+                <p>Manual mode means that instead of attempting to resolve conflicts automatically, the attacking player will be asked to indicate who won
+                the conflict.  It also means that during action windows, there is an additional 'Manual Action' button available to you.  Use this when you
+                want to use a non implemented card action, and the game will know to pass priority to your opponent.</p>
+                <p>You can activate or deactivate manual mode by using the /manual command in chat.</p>
+
                 <h3>Manual Commands</h3>
                 <p>The following manual commands have been implemented in order to allow for a smoother gameplay experience:
                 </p>
@@ -50,6 +60,7 @@ class About extends React.Component {
                     <li>/unclaim-ring ring - Set 'ring' as unclaimed.</li>
                     <li>/honor - Move the state of a character towards honored.</li>
                     <li>/dishonor - Move the state of a character towards dishonored.</li>
+                    <li>/manual - Activate or deactivate manual mode (see above).</li>
                 </ul>
 
                 { /*<h3>Can I help?</h3>

--- a/server/game/dynastycardaction.js
+++ b/server/game/dynastycardaction.js
@@ -16,7 +16,7 @@ class DynastyCardAction extends BaseAbility {
 
     meetsRequirements(context) {
         var {game, player, source} = context;
-        
+
         return (
             game.currentPhase === 'dynasty' &&
             !source.facedown &&

--- a/server/game/dynastycardaction.js
+++ b/server/game/dynastycardaction.js
@@ -1,10 +1,12 @@
 const BaseAbility = require('./baseability.js');
 const Costs = require('./costs.js');
+const ChooseFate = require('./costs/choosefate.js');
 
 class DynastyCardAction extends BaseAbility {
     constructor() {
         super({
             cost: [
+                new ChooseFate(),
                 Costs.payReduceableFateCost('dynasty'),
                 Costs.playLimited()
             ]
@@ -14,21 +16,32 @@ class DynastyCardAction extends BaseAbility {
 
     meetsRequirements(context) {
         var {game, player, source} = context;
-
+        
         return (
             game.currentPhase === 'dynasty' &&
-            source.isDynasty &&
             !source.facedown &&
+            source.isDynasty &&
             source.getType() === 'character' &&
             player.isCardInPlayableLocation(source, 'dynasty') &&
-            player.canPutIntoPlay(source)
+            player.canPutIntoPlay(source) &&
+            game.actionWindow &&
+            game.actionWindow.currentPlayer === player &&
+            game.abilityCardStack.length === 1
         );
     }
 
     executeHandler(context) {
-        context.game.addMessage('{0} dynastys {1} costing {2}', context.player, context.source, context.costs.gold);
-
+        
+        let additionalFate = this.cost[0].fate;
+        let location = context.source.location;
+        
+        context.source.fate = additionalFate;
         context.player.putIntoPlay(context.source, 'dynasty');
+        if(['province 1', 'province 2', 'province 3', 'province 4'].includes(location)) {
+            context.player.moveCard(context.player.dynastyDeck.first(), location);
+        }
+        
+        context.game.addMessage('{0} plays {1} with {2} additional fate', context.player, context.source.name, additionalFate);
     }
 
     isCardAbility() {

--- a/server/game/dynastycardaction.js
+++ b/server/game/dynastycardaction.js
@@ -19,8 +19,8 @@ class DynastyCardAction extends BaseAbility {
 
         return (
             game.currentPhase === 'dynasty' &&
-            !source.facedown &&
             source.isDynasty &&
+            !source.facedown &&
             source.getType() === 'character' &&
             player.isCardInPlayableLocation(source, 'dynasty') &&
             player.canPutIntoPlay(source) &&

--- a/test/server/card/drawcard.hasKeyword.spec.js
+++ b/test/server/card/drawcard.hasKeyword.spec.js
@@ -78,7 +78,7 @@ describe('the DrawCard', function() {
                     this.card = new DrawCard(this.player, { type: 'character', cost: 0, side: 'dynasty', text: 'covert. Restricted. Notarealkeyword.\n Extra text because we need stuff here.' });
                     this.card.location = 'province 1';
                     this.player.provinceOne = _([this.card]);
-                    this.player.playCard(this.card);
+                    this.player.putIntoPlay(this.card);
                     // Resolve events in pipeline.
                     this.game.continue();
                 });

--- a/test/server/dynastycardaction.spec.js
+++ b/test/server/dynastycardaction.spec.js
@@ -2,12 +2,16 @@ const DynastyCardAction = require('../../server/game/dynastycardaction.js');
 
 describe('DynastyCardAction', function () {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'on', 'removeListener']);
+        this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'on', 'removeListener', 'abilityCardStack']);
         this.playerSpy = jasmine.createSpyObj('player', ['canPutIntoPlay', 'isCardInPlayableLocation', 'putIntoPlay']);
         this.cardSpy = jasmine.createSpyObj('card', ['getType']);
+        this.windowSpy = jasmine.createSpyObj('window', ['markActionAsTaken']);
         this.cardSpy.isDynasty = true;
         this.cardSpy.controller = this.playerSpy;
         this.cardSpy.owner = this.playerSpy;
+        this.gameSpy.actionWindow = this.windowSpy;
+        this.windowSpy.currentPlayer = this.playerSpy;
+        this.gameSpy.abilityCardStack = ['framework'];
         this.context = {
             costs: {},
             game: this.gameSpy,


### PR DESCRIPTION
Players will now be prompted with how much fate they want to put on characters they play during the Dynasty phase, avoiding the need of using /add-fate

I changed the corresponding test to match the game state more accurately.  Also made a fix to the keyword test, as it should put the card into play to see how it affects the board.