### PR TITLE
Keywords support

### DIFF
--- a/client/About.jsx
+++ b/client/About.jsx
@@ -34,16 +34,6 @@ class About extends React.Component {
                 much information as possible, including what the problem is, what you were expecting, what you did leading up to it, and if possible include a screenshot.  We are a very small
                 development team and if bugs are not reported, it is unlikely they will get fixed.</p>
 
-                <h3>Manual Mode</h3>    
-                <p>At this stage in development, it is recommended that you make use of manual mode.  As cards are not yet implemented, the game is not able to 
-                correctly determine who will win conflicts, as you will probably make use of card abilities during the combat which will change skill levels, 
-                or add or remove participants from the conflict.  In addition, you may want to use an as-yet-unimplemented ability during an action window, 
-                and the game isn't currently able to recognise them.</p>  
-                <p>Manual mode means that instead of attempting to resolve conflicts automatically, the attacking player will be asked to indicate who won
-                the conflict.  It also means that during action windows, there is an additional 'Manual Action' button available to you.  Use this when you
-                want to use a non implemented card action, and the game will know to pass priority to your opponent.</p>
-                <p>You can activate or deactivate manual mode by using the /manual command in chat.</p>
-
                 <h3>Manual Commands</h3>
                 <p>The following manual commands have been implemented in order to allow for a smoother gameplay experience:
                 </p>
@@ -60,7 +50,6 @@ class About extends React.Component {
                     <li>/unclaim-ring ring - Set 'ring' as unclaimed.</li>
                     <li>/honor - Move the state of a character towards honored.</li>
                     <li>/dishonor - Move the state of a character towards dishonored.</li>
-                    <li>/manual - Activate or deactivate manual mode (see above).</li>
                 </ul>
 
                 { /*<h3>Can I help?</h3>

--- a/client/About.jsx
+++ b/client/About.jsx
@@ -34,6 +34,16 @@ class About extends React.Component {
                 much information as possible, including what the problem is, what you were expecting, what you did leading up to it, and if possible include a screenshot.  We are a very small
                 development team and if bugs are not reported, it is unlikely they will get fixed.</p>
 
+                <h3>Manual Mode</h3>    
+                <p>At this stage in development, it is recommended that you make use of manual mode.  As cards are not yet implemented, the game is not able to 
+                correctly determine who will win conflicts, as you will probably make use of card abilities during the combat which will change skill levels, 
+                or add or remove participants from the conflict.  In addition, you may want to use an as-yet-unimplemented ability during an action window, 
+                and the game isn't currently able to recognise them.</p>  
+                <p>Manual mode means that instead of attempting to resolve conflicts automatically, the attacking player will be asked to indicate who won
+                the conflict.  It also means that during action windows, there is an additional 'Manual Action' button available to you.  Use this when you
+                want to use a non implemented card action, and the game will know to pass priority to your opponent.</p>
+                <p>You can activate or deactivate manual mode by using the /manual command in chat.</p>
+
                 <h3>Manual Commands</h3>
                 <p>The following manual commands have been implemented in order to allow for a smoother gameplay experience:
                 </p>
@@ -50,6 +60,7 @@ class About extends React.Component {
                     <li>/unclaim-ring ring - Set 'ring' as unclaimed.</li>
                     <li>/honor - Move the state of a character towards honored.</li>
                     <li>/dishonor - Move the state of a character towards dishonored.</li>
+                    <li>/manual - Activate or deactivate manual mode (see above).</li>
                 </ul>
 
                 { /*<h3>Can I help?</h3>

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -15,6 +15,7 @@ const ValidKeywords = [
     'restricted',
     'limited',
     'sincerity',
+    'courtesy',
     'pride',
     'covert'
 ];
@@ -60,7 +61,7 @@ class BaseCard {
         this.events = new EventRegistrar(this.game, this);
 
         this.abilities = { actions: [], reactions: [], persistentEffects: [], playActions: [] };
-        this.parseKeywords(cardData.text || '');
+        this.parseKeywords(cardData.text_canonical || '');
         this.parseTraits(cardData.traits || '');
         this.setupCardAbilities(AbilityDsl);
 
@@ -74,8 +75,8 @@ class BaseCard {
     }
 
     parseKeywords(text) {
-        var firstLine = text.split('\n')[0];
-        var potentialKeywords = _.map(firstLine.split('.'), k => k.toLowerCase().trim());
+        var lines = text.split('\n');
+        var potentialKeywords = _.map(lines, k => k.split('.')[0]);
 
         this.keywords = {};
         this.printedKeywords = [];

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -76,22 +76,24 @@ class BaseCard {
 
     parseKeywords(text) {
         var lines = text.split('\n');
-        var potentialKeywords = _.map(lines, k => k.split('.')[0]);
+        var potentialKeywords = [];
+        _.each(lines, line => {
+            line = line.slice(0, -1);
+            _.each(line.split('. '), k => potentialKeywords.push(k));
+        });
 
         this.keywords = {};
         this.printedKeywords = [];
-        this.allowedAttachmentTrait = 'any';
+        this.allowedAttachmentTraits = [];
 
         _.each(potentialKeywords, keyword => {
             if(_.contains(ValidKeywords, keyword)) {
                 this.printedKeywords.push(keyword);
-            } else if(keyword.indexOf('no attachment') === 0) {
-                var match = keyword.match(/no attachments except <[bi]>(.*)<\/[bi]>/);
-                if(match) {
-                    this.allowedAttachmentTrait = match[1];
-                } else {
-                    this.allowedAttachmentTrait = 'none';
-                }
+            } else if(keyword.startsWith('no attachments except')) {
+                var traits = keyword.replace('no attachments except ', '');
+                this.allowedAttachmentTraits = traits.split(' or ');
+            } else if(keyword.startsWith('no attachments')) {
+                this.allowedAttachmentTraits = ['none'];
             }
         });
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -78,6 +78,10 @@ class DrawCard extends BaseCard {
         return this.hasKeyword('pride');
     }
 
+    hasCourtesy() {
+        return this.hasKeyword('courtesy');
+    }
+    
     getCost() {
         return this.cardData.cost;
     }

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -255,10 +255,13 @@ class DrawCard extends BaseCard {
      * attach the passed attachment card.
      */
     allowAttachment(attachment) {
+        if(_.any(this.allowedAttachmentTraits, trait => attachment.hasTrait(trait))) {
+            return true;
+        }
+        
         return (
             this.isBlank() ||
-            this.allowedAttachmentTrait === 'any' ||
-            this.allowedAttachmentTrait !== 'none' && attachment.hasTrait(this.allowedAttachmentTrait)
+            this.allowedAttachmentTraits.length === 0
         );
     }
 

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -34,7 +34,7 @@ class ConflictFlow extends BaseStep {
             new SimpleStep(this.game, () => this.announceDefenderSkill()),
             new ActionWindow(this.game, 'Conflict Action Window', 'conflictAction'),
             new SimpleStep(this.game, () => this.determineWinner()),
-            //new SimpleStep(this.game, () => this.applyKeywords()),
+            new SimpleStep(this.game, () => this.applyKeywords()),
             new SimpleStep(this.game, () => this.applyUnopposed()),
             new SimpleStep(this.game, () => this.checkBreakProvince()),
             new SimpleStep(this.game, () => this.resolveRingEffects()),
@@ -226,11 +226,29 @@ class ConflictFlow extends BaseStep {
     }
 
     applyKeywords() {
-        var winnerCards = this.conflict.getWinnerCards();
-
-        _.each(winnerCards, () => {
-            this.game.checkWinCondition(this.conflict.winner);
-        });
+        if(this.conflict.isAttackerTheWinner()) {
+            _.each(this.conflict.attackers, card => {
+                if(card.hasPride()) {
+                    this.conflict.attackingPlayer.honorCard(card);
+                }
+            });
+            _.each(this.conflict.defenders, card => {
+                if(card.hasPride()) {
+                    this.conflict.defendingPlayer.dishonorCard(card);
+                }
+            });
+        } else if(this.conflict.winner === this.conflict.defendingPlayer) {
+            _.each(this.conflict.attackers, card => {
+                if(card.hasPride()) {
+                    this.conflict.attackingPlayer.dishonorCard(card);
+                }
+            });
+            _.each(this.conflict.defenders, card => {
+                if(card.hasPride()) {
+                    this.conflict.defendingPlayer.honorCard(card);
+                }
+            });
+        }
     }
 
     applyUnopposed() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -654,6 +654,16 @@ class Player extends Spectator {
         this.game.queueSimpleStep(() => {
             attachment.applyPersistentEffects();
         });
+        
+        if(_.size(_.filter(card.attachments, card => card.isRestricted())) > 2) {
+            this.game.promptForSelect(this, {
+                activePromptTitle: 'Choose a card to discard',
+                waitingPromptTitle: 'Waiting for opponent to choose a card to discard',
+                cardCondition: c => c.parent === card && c.isRestricted(),
+                onSelect: (player, card) => player.discardCard(card),
+                source: 'Too many Restricted attachments'
+            })
+        }
 
         if(originalLocation !== 'play area') {
             this.game.raiseEvent('onCardEntersPlay', { card: attachment, playingType: playingType, originalLocation: originalLocation });
@@ -991,7 +1001,7 @@ class Player extends Spectator {
             return;
         }
 
-        if(card.location === 'play area') {
+        if(card.location === 'play area' && (card.isConflict || card.isDynasty)) {
             if(card.owner !== this) {
                 card.owner.moveCard(card, targetLocation);
                 return;
@@ -1014,12 +1024,19 @@ class Player extends Spectator {
 
             this.game.raiseEvent('onCardLeftPlay', params, event => {
                 event.card.leavesPlay();
+                
+                if(card.hasSincerity()) {
+                    this.drawCardsToHand(1);
+                }
+                if(card.hasCourtesy()) {
+                    this.game.addFate(this, 1);
+                }
 
                 if(event.card.parent && event.card.parent.attachments) {
                     event.card.parent.attachments = this.removeCardByUuid(event.card.parent.attachments, event.card.uuid);
                     event.card.parent = undefined;
                 }
-
+                
                 card.moveTo(targetLocation);
             });
         }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -655,14 +655,17 @@ class Player extends Spectator {
             attachment.applyPersistentEffects();
         });
         
-        if(_.size(_.filter(card.attachments, card => card.isRestricted())) > 2) {
+        if(attachment.printedKeywords.includes('restricted') && _.size(_.filter(card.attachments._wrapped, card => card.isRestricted())) > 1) {
             this.game.promptForSelect(this, {
                 activePromptTitle: 'Choose a card to discard',
                 waitingPromptTitle: 'Waiting for opponent to choose a card to discard',
                 cardCondition: c => c.parent === card && c.isRestricted(),
-                onSelect: (player, card) => player.discardCard(card),
+                onSelect: (player, card) => {
+                    player.discardCard(card);
+                    return true;
+                },
                 source: 'Too many Restricted attachments'
-            })
+            });
         }
 
         if(originalLocation !== 'play area') {
@@ -1027,9 +1030,11 @@ class Player extends Spectator {
                 
                 if(card.hasSincerity()) {
                     this.drawCardsToHand(1);
+                    this.game.addMessage('{0} draws a card due to {1}\'s Sincerity', this, card);
                 }
                 if(card.hasCourtesy()) {
                     this.game.addFate(this, 1);
+                    this.game.addMessage('{0} gains a fate due to {1}\'s Courtesy', this, card);
                 }
 
                 if(event.card.parent && event.card.parent.attachments) {

--- a/test/server/card/drawcard.canAttach.spec.js
+++ b/test/server/card/drawcard.canAttach.spec.js
@@ -10,7 +10,7 @@ describe('DrawCard', function() {
     describe('canAttach()', function() {
         describe('when the card is an attachment', function() {
             beforeEach(function() {
-                this.targetCard = new DrawCard(this.owner, { text: '' });
+                this.targetCard = new DrawCard(this.owner, { text_canonical: '' });
                 this.attachment = new DrawCard(this.owner, { type: 'attachment' });
             });
 
@@ -21,7 +21,7 @@ describe('DrawCard', function() {
 
         describe('when the card is not an attachment', function() {
             beforeEach(function() {
-                this.targetCard = new DrawCard(this.owner, { text: '' });
+                this.targetCard = new DrawCard(this.owner, { text_canonical: '' });
                 this.attachment = new DrawCard(this.owner, { type: 'event' });
             });
 
@@ -34,7 +34,7 @@ describe('DrawCard', function() {
     describe('allowAttachment()', function() {
         describe('when the target card does not allow attachments', function() {
             beforeEach(function() {
-                this.targetCard = new DrawCard(this.owner, { text: 'No attachments.' });
+                this.targetCard = new DrawCard(this.owner, { text_canonical: 'no attachments.' });
                 this.attachment = new DrawCard(this.owner, { type: 'attachment' });
             });
 
@@ -55,12 +55,12 @@ describe('DrawCard', function() {
 
         describe('when the target card only allows certain kinds of attachments', function() {
             beforeEach(function() {
-                this.targetCard = new DrawCard(this.owner, { text: 'No attachments except <b>Weapon</b>.' });
+                this.targetCard = new DrawCard(this.owner, { text_canonical: 'no attachments except weapon.' });
             });
 
             describe('and the card text has the target in italics', function() {
                 beforeEach(function() {
-                    this.targetCard = new DrawCard(this.owner, { text: 'No attachments except <i>Weapon</i>.' });
+                    this.targetCard = new DrawCard(this.owner, { text_canonical: 'no attachments except weapon.' });
                 });
 
                 describe('and the attachment has that trait', function() {
@@ -105,9 +105,65 @@ describe('DrawCard', function() {
             });
         });
 
+        describe('when the target card only allows two kinds of attachments', function() {
+            beforeEach(function() {
+                this.targetCard = new DrawCard(this.owner, { text_canonical: 'no attachments except monk or tattoo.' });
+            });
+
+            describe('and the attachment has the first of those traits', function() {
+                beforeEach(function() {
+                    this.attachment = new DrawCard(this.owner, { type: 'attachment', traits: ['monk', 'tattooed'] });
+                });
+
+                it('should return true', function() {
+                    expect(this.targetCard.allowAttachment(this.attachment)).toBe(true);
+                });
+            });
+
+            describe('and the attachment has the second of those traits', function() {
+                beforeEach(function() {
+                    this.attachment = new DrawCard(this.owner, { type: 'attachment', traits: ['condition', 'tattoo'] });
+                });
+
+                it('should return true', function() {
+                    expect(this.targetCard.allowAttachment(this.attachment)).toBe(true);
+                });
+            });
+
+            describe('and the attachment has both of those traits', function() {
+                beforeEach(function() {
+                    this.attachment = new DrawCard(this.owner, { type: 'attachment', traits: ['condition', 'tattoo', 'monk'] });
+                });
+
+                it('should return true', function() {
+                    expect(this.targetCard.allowAttachment(this.attachment)).toBe(true);
+                });
+            });
+
+            describe('and the attachment does not have any of those traits', function() {
+                beforeEach(function() {
+                    this.attachment = new DrawCard(this.owner, { type: 'attachment', traits: ['condition'] });
+                });
+
+                it('should return false', function() {
+                    expect(this.targetCard.allowAttachment(this.attachment)).toBe(false);
+                });
+
+                describe('but the target card is blank', function() {
+                    beforeEach(function() {
+                        this.targetCard.setBlank();
+                    });
+
+                    it('should return true', function() {
+                        expect(this.targetCard.allowAttachment(this.attachment)).toBe(true);
+                    });
+                });
+            });
+        });
+
         describe('when there are no restrictions', function() {
             beforeEach(function() {
-                this.targetCard = new DrawCard(this.owner, { text: '' });
+                this.targetCard = new DrawCard(this.owner, { text_canonical: '' });
                 this.attachment = new DrawCard(this.owner, { type: 'attachment', traits: [] });
             });
 

--- a/test/server/card/drawcard.hasKeyword.spec.js
+++ b/test/server/card/drawcard.hasKeyword.spec.js
@@ -75,7 +75,7 @@ describe('the DrawCard', function() {
 
             describe('when the card has a keyword line', function() {
                 beforeEach(function() {
-                    this.card = new DrawCard(this.player, { type: 'character', cost: 0, side: 'dynasty', text: 'covert. Restricted. Notarealkeyword.\n Extra text because we need stuff here.' });
+                    this.card = new DrawCard(this.player, { type: 'character', cost: 0, side: 'dynasty', text_canonical: 'covert.\nsomestuff. restricted.\nnotarealkeyword.\nextra text because we need stuff here.' });
                     this.card.location = 'province 1';
                     this.player.provinceOne = _([this.card]);
                     this.player.playCard(this.card);

--- a/test/server/player/movecard.spec.js
+++ b/test/server/player/movecard.spec.js
@@ -16,6 +16,7 @@ describe('Player', function() {
                 }
             });
             this.card = new DrawCard(this.player, { code: '1', name: 'Test' });
+            this.card.isConflict = true;
             spyOn(this.card, 'leavesPlay');
         });
 
@@ -109,6 +110,7 @@ describe('Player', function() {
             describe('when the card is an attachment', function() {
                 beforeEach(function() {
                     this.attachment = new DrawCard(this.player, {});
+                    this.attachment.isConflict = true;
                     this.attachment.parent = this.card;
                     this.attachment.location = 'play area';
                     this.card.attachments.push(this.attachment);


### PR DESCRIPTION
The game now automatically gives players the benefit of Sincerity and Courtesy, and enforces Restricted keyword limit.

I also found and fixed a bug with incorrectly parsing keywords from cardData, and also fixed the BaseCard leaving play error.

Update: Tests failed due to BaseCard leaving play and parsing changes.

I've changed the tests to reflect the different way that L5R formats compared to AGoT.  I've also changed keyword parsing to use text_canonical rather than text, as it means we don't need to worry about capitals or formatting.

L5R has cards which 'whitelists' two kinds of attachments (e.g. No attachments except Monk or Tattoo), so I've written code to parse this case (and added tests to check that the code behaves properly in this case).  This means that the DrawCard.allowedAttachmentTraits is now an array, not a string.

I also implemented Pride, so all Keywords are now implemented I think