### PR TITLE
Make Provinces and Stronghold selectable by SelectCardPrompt

### DIFF
--- a/server/game/gamesteps/actionwindow.js
+++ b/server/game/gamesteps/actionwindow.js
@@ -68,7 +68,7 @@ class ActionWindow extends UiPrompt {
         if(choice === 'manual') {
             this.game.promptForSelect(this.currentPlayer, {
                 activePrompt: 'Which ability are you using?',
-                cardCondition: card => (card.controller === this.currentPlayer || card === this.currentPlayer.stronghold),
+                cardCondition: card => (card.controller === this.currentPlayer && !card.facedown),
                 onSelect: (player, card) => {
                     this.game.addMessage('{0} uses {1}\'s ability', player, card);
                     this.markActionAsTaken();

--- a/server/game/gamesteps/dynasty/dynastyactionwindow.js
+++ b/server/game/gamesteps/dynasty/dynastyactionwindow.js
@@ -32,7 +32,7 @@ class DynastyActionWindow extends ActionWindow {
         if(choice === 'manual') {
             this.game.promptForSelect(this.currentPlayer, {
                 activePrompt: 'Which ability are you using?',
-                cardCondition: card => (card.controller === this.currentPlayer || card === this.currentPlayer.stronghold),
+                cardCondition: card => (card.controller === this.currentPlayer && !card.facedown),
                 onSelect: (player, card) => {
                     this.game.addMessage('{0} uses {1}\'s ability', player, card);
                     this.markActionAsTaken();

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -70,7 +70,7 @@ class SelectCardPrompt extends UiPrompt {
             numCards: 1,
             additionalButtons: [],
             cardCondition: () => true,
-            cardType: ['attachment', 'character', 'event', 'location', 'holding'],
+            cardType: ['attachment', 'character', 'event', 'location', 'holding', 'province', 'stronghold'],
             gameAction: 'target',
             onSelect: () => true,
             onMenuCommand: () => true,

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -48,7 +48,7 @@ describe('the SelectCardPrompt', function() {
         describe('cardType', function() {
             it('should default to a list of draw card types', function() {
                 let prompt = new SelectCardPrompt(this.game, this.player, this.properties);
-                expect(prompt.properties.cardType).toEqual(['attachment', 'character', 'event', 'location', 'holding']);
+                expect(prompt.properties.cardType).toEqual(['attachment', 'character', 'event', 'location', 'holding', 'province', 'stronghold']);
             });
 
             it('should let a custom array be set', function() {


### PR DESCRIPTION
Allows Strongholds and Provinces to be selectable targets