### PR TITLE
Can't reveal provinces and ring mouseover

### DIFF
--- a/client/About.jsx
+++ b/client/About.jsx
@@ -52,6 +52,7 @@ class About extends React.Component {
                     <li>/discard x - Discards x cards randomly from your hand</li>
                     <li>/draw x - Draws x cards from your deck to your hand</li>
                     <li>/give-control - Give control of a card to your opponent.  Use with caution</li>
+                    <li>/reveal - Reveal a facedown card.</li>
                     <li>/add-fate x - Add 'x' fate to a card.</li>
                     <li>/rem-fate x - Remove 'x' fate from a card.</li>
                     <li>/add-fate-ring ring x - Add 'x' fate to 'ring'.</li>

--- a/client/About.jsx
+++ b/client/About.jsx
@@ -52,7 +52,6 @@ class About extends React.Component {
                     <li>/discard x - Discards x cards randomly from your hand</li>
                     <li>/draw x - Draws x cards from your deck to your hand</li>
                     <li>/give-control - Give control of a card to your opponent.  Use with caution</li>
-                    <li>/reveal - Reveal a facedown card.</li>
                     <li>/add-fate x - Add 'x' fate to a card.</li>
                     <li>/rem-fate x - Remove 'x' fate from a card.</li>
                     <li>/add-fate-ring ring x - Add 'x' fate to 'ring'.</li>

--- a/client/GameComponents/Ring.jsx
+++ b/client/GameComponents/Ring.jsx
@@ -44,7 +44,7 @@ class Ring extends React.Component {
 
         return (<div className='ring-display'>
             <div className='ring' onClick={ event => this.onClick(event, this.props.ringType) } >
-                <img className='ring' title={ this.props.ringType } src={ '/img/' + this.props.conflictType + '-' + this.props.ringType + '.png' } />
+                <img className='ring' src={ '/img/' + this.props.conflictType + '-' + this.props.ringType + '.png' } />
                 { this.showCounters() ? <CardCounters counters={ this.getCountersForRing(this.props.ringType) } /> : null }
             </div>
             <div className='ring-info' >

--- a/client/GameComponents/Ring.jsx
+++ b/client/GameComponents/Ring.jsx
@@ -44,7 +44,7 @@ class Ring extends React.Component {
 
         return (<div className='ring-display'>
             <div className='ring' onClick={ event => this.onClick(event, this.props.ringType) } >
-                <img className='ring' src={ '/img/' + this.props.conflictType + '-' + this.props.ringType + '.png' } />
+                <img className='ring' title={ this.props.ringType } src={ '/img/' + this.props.conflictType + '-' + this.props.ringType + '.png' } />
                 { this.showCounters() ? <CardCounters counters={ this.getCountersForRing(this.props.ringType) } /> : null }
             </div>
             <div className='ring-info' >

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -18,6 +18,7 @@ class ChatCommands {
             '/reset-challenges-count': this.resetChallengeCount,
             '/cancel-prompt': this.cancelPrompt,
             '/token': this.setToken,
+            '/reveal': this.reveal,
             '/add-fate': this.addFate,
             '/rem-fate': this.remFate,
             '/add-fate-ring': this.addRingFate,
@@ -253,6 +254,18 @@ class ChatCommands {
                 card.addToken(token, num - numTokens);
                 this.game.addMessage('{0} uses the /token command to set the {1} token count of {2} to {3}', p, token, card, num - numTokens);
 
+                return true;
+            }
+        });
+    }
+    
+    reveal(player) {
+        this.game.promptForSelect(player, {
+            activePromptTitle: 'Select a card',
+            cardCondition: card => card.facedown & card.controller === player,
+            onSelect: (player, card) => {
+                card.facedown = false;
+                this.game.addMessage('{0} reveals {1}', player, card);
                 return true;
             }
         });

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -18,7 +18,6 @@ class ChatCommands {
             '/reset-challenges-count': this.resetChallengeCount,
             '/cancel-prompt': this.cancelPrompt,
             '/token': this.setToken,
-            '/reveal': this.reveal,
             '/add-fate': this.addFate,
             '/rem-fate': this.remFate,
             '/add-fate-ring': this.addRingFate,
@@ -254,18 +253,6 @@ class ChatCommands {
                 card.addToken(token, num - numTokens);
                 this.game.addMessage('{0} uses the /token command to set the {1} token count of {2} to {3}', p, token, card, num - numTokens);
 
-                return true;
-            }
-        });
-    }
-    
-    reveal(player) {
-        this.game.promptForSelect(player, {
-            activePromptTitle: 'Select a card',
-            cardCondition: card => card.facedown & card.controller === player,
-            onSelect: (player, card) => {
-                card.facedown = false;
-                this.game.addMessage('{0} reveals {1}', player, card);
                 return true;
             }
         });

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -231,14 +231,13 @@ class Game extends EventEmitter {
 
             this.addMessage('{0} {1} {2}', player, card.bowed ? 'bows' : 'readies', card);
         }
-        /*
-        if(['province 1', 'province 2', 'province 3', 'province 4', 'stronghold province'].includes(card.location) && card.controller === player && (card.isDynasty || card.isProvince)) {
+        
+        if(['province 1', 'province 2', 'province 3', 'province 4', 'stronghold province'].includes(card.location) && card.controller === player && card.isDynasty) {
             if(card.facedown) {
                 card.facedown = false;
                 this.addMessage('{0} reveals {1}', player, card);
             }
-        }
-        */
+        }        
     }
    
     ringClicked(sourcePlayer, ringindex) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -231,13 +231,14 @@ class Game extends EventEmitter {
 
             this.addMessage('{0} {1} {2}', player, card.bowed ? 'bows' : 'readies', card);
         }
-
+        /*
         if(['province 1', 'province 2', 'province 3', 'province 4', 'stronghold province'].includes(card.location) && card.controller === player && (card.isDynasty || card.isProvince)) {
             if(card.facedown) {
                 card.facedown = false;
                 this.addMessage('{0} reveals {1}', player, card);
             }
         }
+        */
     }
    
     ringClicked(sourcePlayer, ringindex) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -231,14 +231,13 @@ class Game extends EventEmitter {
 
             this.addMessage('{0} {1} {2}', player, card.bowed ? 'bows' : 'readies', card);
         }
-        /*
+
         if(['province 1', 'province 2', 'province 3', 'province 4', 'stronghold province'].includes(card.location) && card.controller === player && (card.isDynasty || card.isProvince)) {
             if(card.facedown) {
                 card.facedown = false;
                 this.addMessage('{0} reveals {1}', player, card);
             }
         }
-        */
     }
    
     ringClicked(sourcePlayer, ringindex) {


### PR DESCRIPTION
You can no longer click facedown provinces to reveal them.  Revealing should occur automatically during conflict, but I've also added a chat command in case players need to do so.

Also added mouseovers to rings with their element.