### PR TITLE
Superfluous message removed

### DIFF
--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -348,7 +348,7 @@ class ChatCommands {
         if(_.contains(['air','earth','fire','void','water'], ringElement)) {
             let ring = this.game.rings[ringElement];
 
-            ring.claimRing(player.user.username);
+            ring.claimRing(player);
             this.game.addMessage('{0} uses the /claim-ring command to claim the ring of {1}', player, ringElement);
         }
 

--- a/server/game/gamesteps/honorbidprompt.js
+++ b/server/game/gamesteps/honorbidprompt.js
@@ -8,7 +8,7 @@ class HonorBidPrompt extends AllPlayerPrompt {
         this.menuTitle = menuTitle || 'Choose a bid';
         _.each(game.getPlayers(), player => {
             player.honorBid = 0;
-            player.setShowBid();
+            player.showBid = 0;
         });
     }
     


### PR DESCRIPTION
Currently, players get a message about 0 bids, which shouldn't be displayed. This fixes that.