### PR TITLE
Dash rules

### DIFF
--- a/server/game/conflict.js
+++ b/server/game/conflict.js
@@ -94,6 +94,18 @@ class Conflict {
     switchType() {
         this.conflictType = this.conflictType === 'military' ? 'political' : 'military';
         this.conflictTypeSwitched = true;
+        _.each(this.attackers, card => {
+            if(!card.canParticipateAsAttacker(this.conflictType)) {
+                this.removeFromConflict(card);
+                card.bowed = true;
+            }
+        });
+        _.each(this.defenders, card => {
+            if(!card.canParticipateAsDefender(this.conflictType)) {
+                this.removeFromConflict(card);
+                card.bowed = true;
+            }
+        });
     }
     
     removeFromConflict(card) {

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -54,6 +54,15 @@ class DrawCard extends BaseCard {
         } else if(cardData.side === 'dynasty') {
             this.isDynasty = true;
         }
+        
+        if(cardData.type === 'character') {
+            if(cardData.military === undefined || cardData.military === null) {
+                this.conflictOptions.cannotParticipateIn.military = true;
+            }
+            if(cardData.political === undefined || cardData.political === null) {
+                this.conflictOptions.cannotParticipateIn.political = true;
+            }
+        }
     }
 
     isLimited() {

--- a/server/game/gamesteps/conflict/initiateconflictprompt.js
+++ b/server/game/gamesteps/conflict/initiateconflictprompt.js
@@ -85,10 +85,16 @@ class InitiateConflictPrompt extends UiPrompt {
         if((this.conflict.conflictRing === ring.element && canInitiateOtherConflictType) ||
                 (this.conflict.conflictRing !== ring.element && !canInitiateThisConflictType)) {
             this.game.flipRing(player, ring);
+            _.each(this.conflict.attackers, card => {
+                if(!card.canDeclareAsAttacker(ring.conflictType)) {
+                    this.conflict.removeFromConflict(card);
+                }
+            });
         }
 
         this.conflict.conflictRing = ring.element;
         this.conflict.conflictType = ring.conflictType;
+        this.conflict.calculateSkill();
         return true;
     }
 


### PR DESCRIPTION
Characters with dashes can no longer be declared as attackers, and will be sent home from the conflict if it switches type.