### PR TITLE
allow click to execute card actions without clickToActivate

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -475,6 +475,10 @@ class BaseCard {
 
         return false;
     }
+    
+    getPlayActions() {
+        return _.filter(this.abilities.actions, action => !action.allowMenu());
+    }
 
     getShortSummary() {
         return {

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -75,7 +75,7 @@ class CardAction extends BaseAbility {
     }
 
     allowMenu() {
-        return true;
+        return this.card.location === 'play area';
     }
 
     createContext(player, arg) {

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -381,7 +381,7 @@ class DrawCard extends BaseCard {
     getPlayActions() {
         return StandardPlayActions
             .concat(this.abilities.playActions)
-            .concat(_.filter(this.abilities.actions, action => !action.allowMenu()));
+            .concat(super.getPlayActions());
     }
 
     leavesPlay() {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -222,7 +222,7 @@ class Game extends EventEmitter {
         }
 
         // Attempt to play cards that are not already in the play area.
-        if(['hand', 'province 1', 'province 2', 'province 3', 'province 4'].includes(card.location) && card.getType() !== 'province' && player.playCard(card)) {
+        if(['hand', 'province 1', 'province 2', 'province 3', 'province 4', 'stronghold province'].includes(card.location) && player.playCard(card)) {
             return;
         }
 


### PR DESCRIPTION
This allows abilities to be used without flagging clickToActivate, which I think is actually intended to be used for abilities which can be toggled on and off.

I'm not really happy with the way we have ability initiation set up - I don't think they should use the same system as play actions, but I haven't made any major changes, just made it so that provinces and strongholds use the same system.