### PR TITLE
Refactor how actions initiate

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -132,11 +132,11 @@ class BaseCard {
 
     action(properties) {
         var action = new CardAction(this.game, this, properties);
-
+        /*
         if(!action.isClickToActivate() && action.allowMenu()) {
             var index = this.abilities.actions.length;
             this.menu.push(action.getMenuItem(index));
-        }
+        }*/
         this.abilities.actions.push(action);
     }
 
@@ -487,8 +487,8 @@ class BaseCard {
         return false;
     }
     
-    getPlayActions() {
-        return _.filter(this.abilities.actions, action => !action.allowMenu());
+    getActions() {
+        return this.abilities.actions;
     }
 
     getShortSummary() {

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -472,10 +472,10 @@ class DrawCard extends BaseCard {
         return [];
     }
 
-    getPlayActions() {
+    getActions() {
         return StandardPlayActions
             .concat(this.abilities.playActions)
-            .concat(super.getPlayActions());
+            .concat(super.getActions());
     }
 
     removeAttachment(attachment) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -218,14 +218,15 @@ class Game extends EventEmitter {
             return;
         }
 
-        // Attempt to play cards that are not already in the play area.
-        if(['hand', 'province 1', 'province 2', 'province 3', 'province 4', 'stronghold province'].includes(card.location) && player.playCard(card)) {
-            return;
-        }
-
         if(card.onClick(player)) {
             return;
         }
+
+        //Look for actions or play actions.
+        if(player.findAndUseAction(card)) {
+            return;
+        }
+
 
         if(!card.facedown && card.location === 'play area' && card.controller === player) {
             if(card.bowed) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -574,7 +574,7 @@ class Player extends Spectator {
         }
     }
 
-    playCard(card) {
+    findAndUseAction(card) {
         if(!card) {
             return false;
         }
@@ -585,16 +585,16 @@ class Player extends Spectator {
             source: card
         };
 
-        var playActions = _.filter(card.getPlayActions(), action => action.meetsRequirements(context) && action.canPayCosts(context) && action.canResolveTargets(context));
+        var actions = _.filter(card.getActions(), action => action.meetsRequirements(context) && action.canPayCosts(context) && action.canResolveTargets(context));
 
-        if(playActions.length === 0) {
+        if(actions.length === 0) {
             return false;
         }
 
-        if(playActions.length === 1) {
-            this.game.resolveAbility(playActions[0], context);
+        if(actions.length === 1) {
+            this.game.resolveAbility(actions[0], context);
         } else {
-            this.game.queueStep(new PlayActionPrompt(this.game, this, playActions, context));
+            this.game.queueStep(new PlayActionPrompt(this.game, this, actions, context));
         }
 
         return true;


### PR DESCRIPTION
- remove menus for characters in play
- all actions are triggered by just clicking on the card you want to use
- use PlayActionPrompt in cases where a character has multiple actions available