### PR TITLE
Pre-targeting on abilities

### DIFF
--- a/server/game/AbilityTargets/AbilityTargetCard.js
+++ b/server/game/AbilityTargets/AbilityTargetCard.js
@@ -13,7 +13,7 @@ class AbilityTargetCard {
         return this.selector.hasEnoughTargets(context);
     }
 
-    resolve(context, pretarget = false) {
+    resolve(context, pretarget = false, noCostsFirstButton = false) {
         let otherProperties = _.omit(this.properties, 'cardCondition');
         let result = { resolved: false, name: this.name, value: null, costsFirst: false };
         let player = context.player;
@@ -29,12 +29,23 @@ class AbilityTargetCard {
             buttons.push({ text: 'No more targets', arg: 'noMoreTargets' });
         }
         if(pretarget) {
-            buttons.push({ text: 'Pay costs first', arg: 'costsFirst' });
+            if(!noCostsFirstButton) {
+                buttons.push({ text: 'Pay costs first', arg: 'costsFirst' });
+            }
             buttons.push({ text: 'Cancel', arg: 'done' });
         } else {
             buttons.push({ text: 'Done', arg: 'done' });
         }
+        let waitingPromptTitle = '';
+        if(pretarget) {
+            if(context.ability.abilityType === 'action') {
+                waitingPromptTitle = 'Waiting for opponent to take an action or pass';
+            } else {
+                waitingPromptTitle = 'Waiting for opponent';
+            }
+        }
         let promptProperties = {
+            waitingPromptTitle: waitingPromptTitle,
             context: context,
             source: context.source,
             selector: this.selector,

--- a/server/game/AbilityTargets/AbilityTargetCard.js
+++ b/server/game/AbilityTargets/AbilityTargetCard.js
@@ -1,0 +1,79 @@
+const _ = require('underscore');
+
+const CardSelector = require('../CardSelector.js');
+
+class AbilityTargetCard {
+    constructor(name, properties) {
+        this.name = name;
+        this.properties = properties;
+        this.selector = CardSelector.for(properties);
+    }
+
+    canResolve(context) {
+        return this.selector.hasEnoughTargets(context);
+    }
+
+    resolve(context, pretarget = false) {
+        let otherProperties = _.omit(this.properties, 'cardCondition');
+        let result = { resolved: false, name: this.name, value: null, costsFirst: false };
+        let player = context.player;
+        if(this.properties.player && this.properties.player === 'opponent') {
+            if(pretarget) {
+                result.costsFirst = true;
+                return result;
+            }
+            player = player.opponent;
+        }
+        let buttons = [];
+        if(this.properties.optional) {
+            buttons.push({ text: 'No more targets', arg: 'noMoreTargets' });
+        }
+        if(pretarget) {
+            buttons.push({ text: 'Pay costs first', arg: 'costsFirst' });
+            buttons.push({ text: 'Cancel', arg: 'done' });
+        } else {
+            buttons.push({ text: 'Done', arg: 'done' });
+        }
+        let promptProperties = {
+            context: context,
+            source: context.source,
+            selector: this.selector,
+            buttons: buttons,
+            onSelect: (player, card) => {
+                result.resolved = true;
+                result.value = card;
+                return true;
+            },
+            onCancel: () => {
+                result.resolved = true;
+                return true;
+            },
+            onMenuCommand: (player, arg) => {
+                if(arg === 'costsFirst') {
+                    result.costsFirst = true;
+                    return true;
+                }
+                result.resolved = true;
+                result.value = arg;
+                return true;
+            }
+        };
+        context.game.promptForSelect(player, _.extend(promptProperties, otherProperties));
+        return result;
+    }
+    
+    checkTarget(context) {
+        if(this.properties.optional || context.targets[this.name] === 'noMoreTargets') {
+            return true;
+        }
+        let cards = context.targets[this.name];
+        if(!_.isArray(cards)) {
+            cards = [cards];
+        }
+        return (_.all(cards, card => this.selector.canTarget(card, context)) &&
+                this.selector.hasEnoughSelected(cards) &&
+                !this.selector.hasExceededLimit(cards));
+    }
+}
+
+module.exports = AbilityTargetCard;

--- a/server/game/AbilityTargets/AbilityTargetRing.js
+++ b/server/game/AbilityTargets/AbilityTargetRing.js
@@ -10,7 +10,7 @@ class AbilityTargetCard {
         return _.any(context.game.rings, ring => this.properties.ringCondition(ring));
     }
 
-    resolve(context, pretarget = false) {
+    resolve(context, pretarget = false, noCostsFirstButton = false) {
         let result = { resolved: false, name: this.name, value: null, costsFirst: false };
         let player = context.player;
         if(this.properties.player && this.properties.player === 'opponent') {
@@ -25,12 +25,23 @@ class AbilityTargetCard {
             buttons.push({ text: 'No more targets', arg: 'noMoreTargets' });
         }
         if(pretarget) {
-            buttons.push({ text: 'Pay costs first', arg: 'costsFirst' });
+            if(!noCostsFirstButton) {
+                buttons.push({ text: 'Pay costs first', arg: 'costsFirst' });
+            }
             buttons.push({ text: 'Cancel', arg: 'done' });
         } else {
             buttons.push({ text: 'Done', arg: 'done' });
         }
+        let waitingPromptTitle = '';
+        if(pretarget) {
+            if(context.ability.abilityType === 'action') {
+                waitingPromptTitle = 'Waiting for opponent to take an action or pass';
+            } else {
+                waitingPromptTitle = 'Waiting for opponent';
+            }
+        }
         let promptProperties = {
+            waitingPromptTitle: waitingPromptTitle,
             context: context,
             source: context.source,
             buttons: buttons,

--- a/server/game/AbilityTargets/AbilityTargetRing.js
+++ b/server/game/AbilityTargets/AbilityTargetRing.js
@@ -1,0 +1,65 @@
+const _ = require('underscore');
+
+class AbilityTargetCard {
+    constructor(name, properties) {
+        this.name = name;
+        this.properties = properties;
+    }
+
+    canResolve(context) {
+        return _.any(context.game.rings, ring => this.properties.ringCondition(ring));
+    }
+
+    resolve(context, pretarget = false) {
+        let result = { resolved: false, name: this.name, value: null, costsFirst: false };
+        let player = context.player;
+        if(this.properties.player && this.properties.player === 'opponent') {
+            if(pretarget) {
+                result.costsFirst = true;
+                return result;
+            }
+            player = player.opponent;
+        }
+        let buttons = [];
+        if(this.properties.optional) {
+            buttons.push({ text: 'No more targets', arg: 'noMoreTargets' });
+        }
+        if(pretarget) {
+            buttons.push({ text: 'Pay costs first', arg: 'costsFirst' });
+            buttons.push({ text: 'Cancel', arg: 'done' });
+        } else {
+            buttons.push({ text: 'Done', arg: 'done' });
+        }
+        let promptProperties = {
+            context: context,
+            source: context.source,
+            buttons: buttons,
+            onSelect: (player, ring) => {
+                result.resolved = true;
+                result.value = ring;
+                return true;
+            },
+            onCancel: () => {
+                result.resolved = true;
+                return true;
+            },
+            onMenuCommand: (player, arg) => {
+                if(arg === 'costsFirst') {
+                    result.costsFirst = true;
+                    return true;
+                }
+                result.resolved = true;
+                result.value = arg;
+                return true;
+            }
+        };
+        context.game.promptForRingSelect(player, _.extend(promptProperties, this.properties));
+        return result;
+    }
+    
+    checkTarget(context) {
+        return this.properties.ringCondition(context.targets[this.name]);
+    }
+}
+
+module.exports = AbilityTargetCard;

--- a/server/game/AbilityTargets/AbilityTargetSelect.js
+++ b/server/game/AbilityTargets/AbilityTargetSelect.js
@@ -1,0 +1,52 @@
+const _ = require('underscore');
+
+class AbilityTargetSelect {
+    constructor(name, properties) {
+        this.name = name;
+        this.properties = properties;
+    }
+
+    canResolve(context) {
+        return _.any(this.properties.choices, condition => condition(context));
+    }
+
+    resolve(context, pretarget = false) {
+        let result = { resolved: false, name: this.name, value: null, costsFirst: false };
+        let player = context.player;
+        if(this.properties.player && this.properties.player === 'opponent') {
+            if(pretarget) {
+                result.costsFirst = true;
+                return result;
+            }
+            player = player.opponent;
+        }
+        let promptTitle = this.properties.activePromptTitle || 'Select one';
+        let choices = _.filter(_.keys(this.properties.choices), key => this.properties.choices[key]());
+        let handlers = _.map(this.properties.choices, choice => {
+            return (() => {
+                result.resolved = true;
+                result.value = choice;
+            });
+        });
+        if(this.properties.player !== 'opponent' && pretarget) {
+            choices.push('Pay costs first');
+            handlers.push(() => result.costsFirst = true);
+            choices.push('Cancel');
+            handlers.push(() => result.resolved = true);
+        }
+        context.game.promptWithHandlerMenu(player, {
+            activePromptTitle: promptTitle,
+            context: context,
+            source: context.source,
+            choices: choices,
+            handlers: handlers
+        });
+        return result;
+    }
+    
+    checkTarget(context) {
+        return this.properties.choices[context.targets[this.name]](context);
+    }
+}
+
+module.exports = AbilityTargetSelect;

--- a/server/game/CardSelector.js
+++ b/server/game/CardSelector.js
@@ -1,7 +1,5 @@
 const ExactlyXCardSelector = require('./CardSelectors/ExactlyXCardSelector');
 const MaxStatCardSelector = require('./CardSelectors/MaxStatCardSelector');
-const RingSelector = require('./CardSelectors/RingSelector');
-const SelectSelector = require('./CardSelectors/SelectSelector');
 const SingleCardSelector = require('./CardSelectors/SingleCardSelector');
 const UnlimitedCardSelector = require('./CardSelectors/UnlimitedCardSelector');
 const UpToXCardSelector = require('./CardSelectors/UpToXCardSelector');
@@ -17,8 +15,6 @@ const defaultProperties = {
 const ModeToSelector = {
     exactly: p => new ExactlyXCardSelector(p.numCards, p),
     maxStat: p => new MaxStatCardSelector(p),
-    ring: p => new RingSelector(p),
-    select: p => new SelectSelector(p),
     single: p => new SingleCardSelector(p),
     unlimited: p => new UnlimitedCardSelector(p),
     upTo: p => new UpToXCardSelector(p.numCards, p)

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -41,6 +41,10 @@ class BaseCardSelector {
     hasReachedLimit(selectedCards) { // eslint-disable-line no-unused-vars
         return false;
     }
+    
+    hasExceededLimit(selectedCards) { // eslint-disable-line no-unused-vars
+        return false;
+    }
 
     formatSelectParam(cards) {
         return cards;

--- a/server/game/CardSelectors/MaxStatCardSelector.js
+++ b/server/game/CardSelectors/MaxStatCardSelector.js
@@ -22,6 +22,11 @@ class MaxStatCardSelector extends BaseCardSelector {
         let currentStatSum = selectedCards.reduce((sum, c) => sum + this.cardStat(c), 0);
         return currentStatSum >= this.maxStat();
     }
+    
+    hasExceededLimit(selectedCards) {
+        let currentStatSum = selectedCards.reduce((sum, c) => sum + this.cardStat(c), 0);
+        return currentStatSum > this.maxStat();
+    }
 }
 
 module.exports = MaxStatCardSelector;

--- a/server/game/CardSelectors/SingleCardSelector.js
+++ b/server/game/CardSelectors/SingleCardSelector.js
@@ -25,6 +25,10 @@ class SingleCardSelector extends BaseCardSelector {
         return selectedCards.length >= this.numCards;
     }
 
+    hasExceededLimit(selectedCards) {
+        return selectedCards.length > this.numCards;
+    }
+
     formatSelectParam(cards) {
         return cards[0];
     }

--- a/server/game/CardSelectors/UpToXCardSelector.js
+++ b/server/game/CardSelectors/UpToXCardSelector.js
@@ -14,6 +14,10 @@ class UpToXCardSelector extends BaseCardSelector {
     hasReachedLimit(selectedCards) {
         return selectedCards.length >= this.numCards;
     }
+    
+    hasExceededLimit(selectedCards) {
+        return selectedCards.length > this.numCards;
+    }
 }
 
 module.exports = UpToXCardSelector;

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -158,7 +158,8 @@ class BaseAbility {
         });
         */
         if(results.length === 0) {
-            return this.targets.map(target => target.resolve(context, true));
+            let canIgnoreAllCosts = _.all(this.costs, cost => cost.canIgnoreForTargeting);
+            return this.targets.map(target => target.resolve(context, true, canIgnoreAllCosts));
         }
         return _.map(_.zip(this.targets, results), array => {
             let [target, result] = array;

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -55,6 +55,7 @@ class CardAction extends BaseAbility {
         this.printedAbility = properties.printedAbility === false ? false : true;
         this.cannotBeCopied = properties.cannotBeCopied;
         this.cannotBeCancelled = properties.cannotBeCancelled;
+        this.cannotTargetFirst = !!properties.cannotTargetFirst;
         this.methods = properties.methods || [];
         this.activationContexts = [];
 

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -361,7 +361,8 @@ const Costs = {
             },
             pay: function(context) {
                 context.source.controller.moveCard(context.source, 'conflict discard pile');
-            }
+            },
+            canIgnoreForTargeting: true
         };
     },
     /**
@@ -434,7 +435,8 @@ const Costs = {
                 if(context.source.isLimited()) {
                     context.player.limitedPlayed += 1;
                 }
-            }
+            },
+            canIgnoreForTargeting: true
         };
     },
     /**
@@ -448,7 +450,8 @@ const Costs = {
             },
             pay: function(context) {
                 context.player.incrementAbilityMax(context.source.name);
-            }
+            },
+            canIgnoreForTargeting: true
         };
     },
     /**
@@ -463,7 +466,8 @@ const Costs = {
             pay: function(context) {
 
                 context.player.fate -= context.source.getCost();
-            }
+            },
+            canIgnoreForTargeting: true
         };
     },
     /**
@@ -482,8 +486,8 @@ const Costs = {
                 context.costs.fate = context.player.getReducedCost(playingType, context.source);
                 context.player.fate -= context.costs.fate;
                 context.player.markUsedReducers(playingType, context.source);
-
-            }
+            },
+            canIgnoreForTargeting: true
         };
     },
     /**
@@ -496,7 +500,8 @@ const Costs = {
             },
             pay: function(context) {
                 context.game.addFate(context.player, -amount);
-            }
+            },
+            canIgnoreForTargeting: true
         };
     },
     /**

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -11,6 +11,7 @@ class AbilityResolver extends BaseStep {
 
         this.ability = ability;
         this.context = context;
+        this.context.ability = ability;
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
             new SimpleStep(game, () => this.setNoNewActions()),
@@ -117,7 +118,13 @@ class AbilityResolver extends BaseStep {
         }
 
         this.context.targets = {};
-        this.targetResults = this.ability.resolveTargets(this.context);
+        if(this.ability.cannotTargetFirst) {
+            this.targetResults = _.map(this.ability.targets, (props, name) => {
+                return { resolved: false, name: name, value: null, costsFirst: true };
+            });
+        } else {
+            this.targetResults = this.ability.resolveTargets(this.context);
+        }
     }
 
     resolveTargets() {

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -16,7 +16,7 @@ class AbilityResolver extends BaseStep {
         this.pipeline.initialise([
             new SimpleStep(game, () => this.setNoNewActions()),
             new SimpleStep(game, () => this.resolveEarlyTargets()),
-            new SimpleStep(game, () => this.waitForTargetResolution()),
+            new SimpleStep(game, () => this.waitForTargetResolution(true)),
             new SimpleStep(game, () => this.game.pushAbilityContext('card', context.source, 'cost')),
             new SimpleStep(game, () => this.resolveCosts()),
             new SimpleStep(game, () => this.waitForCostResolution()),
@@ -135,14 +135,14 @@ class AbilityResolver extends BaseStep {
         this.targetResults = this.ability.resolveTargets(this.context, this.targetResults);
     }
 
-    waitForTargetResolution() {
+    waitForTargetResolution(pretarget = false) {
         if(this.cancelled) {
             return;
         }
 
         this.cancelled = _.any(this.targetResults, result => result.resolved && !result.value);
 
-        if(!_.all(this.targetResults, result => result.resolved || result.costsFirst)) {
+        if(!_.all(this.targetResults, result => result.resolved || (pretarget && result.costsFirst))) {
             return false;
         }
 

--- a/server/game/gamesteps/actionwindow.js
+++ b/server/game/gamesteps/actionwindow.js
@@ -54,7 +54,7 @@ class ActionWindow extends UiPrompt {
     }
 
     waitingPrompt() {
-        return { menuTitle: 'Waiting for opponent to take an action or pass.' };
+        return { menuTitle: 'Waiting for opponent to take an action or pass' };
     }
 
     onMenuCommand(player, choice) {

--- a/server/game/gamesteps/selectringprompt.js
+++ b/server/game/gamesteps/selectringprompt.js
@@ -38,7 +38,7 @@ class SelectRingPrompt extends UiPrompt {
 
     defaultProperties() {
         return {
-            additionalButtons: [],
+            buttons: [{ text: 'Done', arg: 'done' }],
             ringCondition: () => true,
             onSelect: () => true,
             onMenuCommand: () => true,
@@ -52,12 +52,11 @@ class SelectRingPrompt extends UiPrompt {
 
     activePrompt() {
         return {
+            source: this.properties.source,
             selectCard: true,
             selectOrder: this.properties.ordered,
             menuTitle: this.properties.activePromptTitle || this.defaultActivePromptTitle(),
-            buttons: this.properties.additionalButtons.concat([
-                { text: 'Done', arg: 'done' }
-            ]),
+            buttons: this.properties.buttons,
             promptTitle: this.properties.source ? this.properties.source.name : undefined
         };
     }

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -110,7 +110,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
                 buttons: buttons,
                 controls: this.getAdditionalPromptControls()
             },
-            waitingPromptTitle: 'Waiting for opponents'
+            waitingPromptTitle: 'Waiting for opponent'
         });
 
         this.forceWindowPerPlayer[player.name] = false;

--- a/server/game/playattachmentaction.js
+++ b/server/game/playattachmentaction.js
@@ -13,6 +13,8 @@ class PlayAttachmentAction extends BaseAbility {
             }
         });
         this.title = 'PlayAttachmentAction';
+        this.cannotTargetFirst = false;
+        this.abilityType = 'action';
     }
     
     meetsRequirements(context) {

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -30,6 +30,7 @@ class TriggeredAbility extends BaseAbility {
         this.abilityType = abilityType;
         this.printedAbility = properties.printedAbility === false ? false : true;
         this.methods = properties.methods || [];
+        this.cannotTargetFirst = !!properties.cannotTargetFirst;
         this.location = properties.location || [];
         if(!_.isArray(this.location)) {
             this.location = [this.location];

--- a/test/server/card/baseability.spec.js
+++ b/test/server/card/baseability.spec.js
@@ -250,17 +250,17 @@ describe('BaseAbility', function () {
             this.properties.targets = { target1: this.target1, target2: this.target2 };
             this.ability = new BaseAbility(this.properties);
 
-            this.context = { game: this.gameSpy, player: this.player, source: this.source };
+            this.context = { game: this.gameSpy, player: this.player, source: this.source, ability: this.ability };
         });
 
         it('should return target results for each target', function() {
-            expect(this.ability.resolveTargets(this.context)).toEqual([{ resolved: false, name: 'target1', value: null }, { resolved: false, name: 'target2', value: null }]);
+            expect(this.ability.resolveTargets(this.context)).toEqual([{ resolved: false, name: 'target1', value: null, costsFirst: false }, { resolved: false, name: 'target2', value: null, costsFirst: false }]);
         });
 
         it('should prompt the player to select each target', function() {
             this.ability.resolveTargets(this.context);
-            expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.player, { source: this.source, target: 1, onSelect: jasmine.any(Function), onCancel: jasmine.any(Function), selector: jasmine.any(Object), context: this.context });
-            expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.player, { source: this.source, target: 2, onSelect: jasmine.any(Function), onCancel: jasmine.any(Function), selector: jasmine.any(Object), context: this.context });
+            expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.player, { source: this.source, target: 1, onSelect: jasmine.any(Function), onCancel: jasmine.any(Function), selector: jasmine.any(Object), context: this.context, waitingPromptTitle: jasmine.any(String), buttons: jasmine.any(Array), onMenuCommand: jasmine.any(Function) });
+            expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.player, { source: this.source, target: 1, onSelect: jasmine.any(Function), onCancel: jasmine.any(Function), selector: jasmine.any(Object), context: this.context, waitingPromptTitle: jasmine.any(String), buttons: jasmine.any(Array), onMenuCommand: jasmine.any(Function) });
         });
 
         describe('the select prompt', function() {

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -31,6 +31,8 @@ describe('AbilityResolver', function() {
 
         describe('when all costs can be paid', function() {
             beforeEach(function() {
+                this.targetResult = { resolved: true, name: 'foo', value: 'foo', costsFirst: false };
+                this.ability.resolveTargets.and.returnValue([this.targetResult]);
                 this.ability.resolveCosts.and.returnValue([{ resolved: true, value: true }, { resolved: true, value: true }]);
                 this.resolver.continue();
             });
@@ -155,7 +157,7 @@ describe('AbilityResolver', function() {
 
         describe('when there are targets that need to be resolved', function() {
             beforeEach(function() {
-                this.targetResult = { resolved: false, name: 'foo', value: null };
+                this.targetResult = { resolved: false, name: 'foo', value: null, costsFirst: true };
                 this.ability.resolveTargets.and.returnValue([this.targetResult]);
                 this.resolver.continue();
             });


### PR DESCRIPTION
Changed the ability resolver to do targeting before choosing/paying costs.  This allows:
 - implementation of cards which require targets to be selected to reduce their costs (Daimyo's Favor)
 - players to cancel abilities which they've clicked on once they realise that the target they wanted can't be chosen, or just change their mind

In some cases, payment of costs may impact the targets available, so where that is the case, players can choose to pay costs first.  If they target first, and then payment of costs invalidates some or all of those targets, they will be asked to rechoose any invalid targets.