### PR TITLE
Add menus for use in manual mode

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -45,6 +45,7 @@ export class InnerGameBoard extends React.Component {
         this.onChange = this.onChange.bind(this);
         this.onScroll = this.onScroll.bind(this);
         this.onMenuItemClick = this.onMenuItemClick.bind(this);
+        this.onRingMenuItemClick = this.onRingMenuItemClick.bind(this);
 
         this.state = {
             canScroll: true,
@@ -325,6 +326,10 @@ export class InnerGameBoard extends React.Component {
         this.props.sendGameMessage('menuItemClick', card.uuid, menuItem);
     }
 
+    onRingMenuItemClick(ring, menuItem) {
+        this.props.sendGameMessage('ringMenuItemClick', ring, menuItem);
+    }
+
     onPromptedActionWindowToggle(option, value) {
         this.props.sendGameMessage('togglePromptedActionWindow', option, value);
     }
@@ -347,11 +352,11 @@ export class InnerGameBoard extends React.Component {
 
     getRings() {
         return (<div className='panel ring-panel'>
-            <Ring ring={ this.props.currentGame.rings.air } onClick={ this.onRingClick } size={ this.props.user.settings.cardSize } />
-            <Ring ring={ this.props.currentGame.rings.earth } onClick={ this.onRingClick } size={ this.props.user.settings.cardSize } />
-            <Ring ring={ this.props.currentGame.rings.fire } onClick={ this.onRingClick } size={ this.props.user.settings.cardSize } />
-            <Ring ring={ this.props.currentGame.rings.void } onClick={ this.onRingClick } size={ this.props.user.settings.cardSize } />
-            <Ring ring={ this.props.currentGame.rings.water } onClick={ this.onRingClick } size={ this.props.user.settings.cardSize } />
+            <Ring ring={ this.props.currentGame.rings.air } onClick={ this.onRingClick } size={ this.props.user.settings.cardSize } onMenuItemClick={ this.onRingMenuItemClick } />
+            <Ring ring={ this.props.currentGame.rings.earth } onClick={ this.onRingClick } size={ this.props.user.settings.cardSize } onMenuItemClick={ this.onRingMenuItemClick } />
+            <Ring ring={ this.props.currentGame.rings.fire } onClick={ this.onRingClick } size={ this.props.user.settings.cardSize } onMenuItemClick={ this.onRingMenuItemClick } />
+            <Ring ring={ this.props.currentGame.rings.void } onClick={ this.onRingClick } size={ this.props.user.settings.cardSize } onMenuItemClick={ this.onRingMenuItemClick } />
+            <Ring ring={ this.props.currentGame.rings.water } onClick={ this.onRingClick } size={ this.props.user.settings.cardSize } onMenuItemClick={ this.onRingMenuItemClick } />
         </div>);
     }
 
@@ -536,6 +541,7 @@ export class InnerGameBoard extends React.Component {
                                 spectating={ this.state.spectating }
                                 onCardClick={ this.onCardClick }
                                 onDragDrop={ this.onDragDrop }
+                                onMenuItemClick={ this.onMenuItemClick } 
                                 onMouseOver={ this.onMouseOver }
                                 onMouseOut={ this.onMouseOut }
                                 strongholdProvinceCards={ thisPlayer.strongholdProvince }

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -103,14 +103,14 @@ class Card extends React.Component {
     }
 
     isAllowedMenuSource() {
-        return this.props.source === 'play area' || this.props.source === 'agenda' || this.props.source === 'revealed plots';
+        return this.props.source === 'play area';
     }
 
     onClick(event, card) {
         event.preventDefault();
         event.stopPropagation();
 
-        if(this.isAllowedMenuSource() && !_.isEmpty(this.props.card.menu)) {
+        if(!_.isEmpty(this.props.card.menu)) {
             this.setState({ showMenu: !this.state.showMenu });
 
             return;
@@ -199,9 +199,10 @@ class Card extends React.Component {
     }
 
     showMenu() {
+        /*
         if(!this.isAllowedMenuSource()) {
             return false;
-        }
+        }*/
 
         if(!this.props.card.menu || !this.state.showMenu) {
             return false;

--- a/client/GameComponents/DynastyRow.jsx
+++ b/client/GameComponents/DynastyRow.jsx
@@ -256,12 +256,11 @@ class DynastyRow extends React.Component {
                             hiddenTopCard cardCount={ this.props.numDynastyCards } 
                             popupMenu={ dynastyDeckPopupMenu } 
                             size={ this.props.cardSize } />
-                        { /* Add Provinces in here */ }
 
-                        <Province isMe={ this.props.isMe } source='province 1' cards={ this.props.province1Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onDragDrop={ this.props.onDragDrop } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } />
-                        <Province isMe={ this.props.isMe } source='province 2' cards={ this.props.province2Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onDragDrop={ this.props.onDragDrop } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } />
-                        <Province isMe={ this.props.isMe } source='province 3' cards={ this.props.province3Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onDragDrop={ this.props.onDragDrop } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } />
-                        <Province isMe={ this.props.isMe } source='province 4' cards={ this.props.province4Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onDragDrop={ this.props.onDragDrop } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } />
+                        <Province isMe={ this.props.isMe } source='province 1' cards={ this.props.province1Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onDragDrop={ this.props.onDragDrop } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } onMenuItemClick={ this.props.onMenuItemClick } />
+                        <Province isMe={ this.props.isMe } source='province 2' cards={ this.props.province2Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onDragDrop={ this.props.onDragDrop } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } onMenuItemClick={ this.props.onMenuItemClick } />
+                        <Province isMe={ this.props.isMe } source='province 3' cards={ this.props.province3Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onDragDrop={ this.props.onDragDrop } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } onMenuItemClick={ this.props.onMenuItemClick } />
+                        <Province isMe={ this.props.isMe } source='province 4' cards={ this.props.province4Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onDragDrop={ this.props.onDragDrop } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } onMenuItemClick={ this.props.onMenuItemClick } />
 
                         <CardPile 
                             className='conflict draw' 
@@ -324,11 +323,11 @@ class DynastyRow extends React.Component {
                         cardCount={ this.props.numConflictCards } 
                         popupMenu={ conflictDeckPopupMenu }
                         size={ this.props.cardSize } />
-                    { /* Add Provinces in here */ }
-                    <Province isMe={ this.props.isMe } source='province 4' cards={ this.props.province4Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } />
-                    <Province isMe={ this.props.isMe } source='province 3' cards={ this.props.province3Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } />
-                    <Province isMe={ this.props.isMe } source='province 2' cards={ this.props.province2Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } />
-                    <Province isMe={ this.props.isMe } source='province 1' cards={ this.props.province1Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } />
+
+                    <Province isMe={ this.props.isMe } source='province 4' cards={ this.props.province4Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } onMenuItemClick={ this.props.onMenuItemClick } />
+                    <Province isMe={ this.props.isMe } source='province 3' cards={ this.props.province3Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } onMenuItemClick={ this.props.onMenuItemClick } />
+                    <Province isMe={ this.props.isMe } source='province 2' cards={ this.props.province2Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } onMenuItemClick={ this.props.onMenuItemClick } />
+                    <Province isMe={ this.props.isMe } source='province 1' cards={ this.props.province1Cards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } disablePopup size={ this.props.cardSize } onMenuItemClick={ this.props.onMenuItemClick } />
 
                     <CardPile 
                         className='dynasty deck' 

--- a/client/GameComponents/Ring.jsx
+++ b/client/GameComponents/Ring.jsx
@@ -4,20 +4,40 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import CardCounters from './CardCounters.jsx';
+import CardMenu from './CardMenu.jsx';
 
 class Ring extends React.Component {
     constructor() {
         super();
 
         this.onClick = this.onClick.bind(this);
+        this.onMenuItemClick = this.onMenuItemClick.bind(this);
+
+        this.state = {
+            showMenu: false
+        };
+
     }
 
     onClick(event, ring) {
         event.preventDefault();
         event.stopPropagation();
 
+        if(!_.isEmpty(this.props.ring.menu)) {
+            this.setState({ showMenu: !this.state.showMenu });
+
+            return;
+        }
+
         if(this.props.onClick) {
             this.props.onClick(ring);
+        }
+    }
+
+    onMenuItemClick(menuItem) {
+        if(this.props.onMenuItemClick) {
+            this.props.onMenuItemClick(this.props.ring, menuItem);
+            this.setState({ showMenu: !this.state.showMenu });
         }
     }
 
@@ -41,6 +61,14 @@ class Ring extends React.Component {
         return true;
     }
 
+    showMenu() {
+        if(!this.props.ring.menu || !this.state.showMenu) {
+            return false;
+        }
+
+        return true;
+    }
+
     render() {
 
         return (<div className='ring-display'>
@@ -51,6 +79,7 @@ class Ring extends React.Component {
             <div className={ this.props.ring.claimedBy.length > 12 ? 'ring-info-xs ' : 'ring-info ' } >
                 { this.props.ring.claimed ? 'Claimed: ' + this.props.ring.claimedBy : this.props.ring.contested ? 'Contested' : 'Unclaimed' }
             </div>
+            { this.showMenu() ? <CardMenu menu={ this.props.ring.menu } onMenuItemClick={ this.onMenuItemClick } /> : null }
         </div>);
     }
 }
@@ -59,6 +88,7 @@ Ring.displayName = 'Ring';
 Ring.propTypes = {
     buttons: PropTypes.array,
     onClick: PropTypes.func,
+    onMenuItemClick: PropTypes.func,
     ring: PropTypes.object,
     size: PropTypes.string,
     socket: PropTypes.object

--- a/client/GameComponents/StrongholdRow.jsx
+++ b/client/GameComponents/StrongholdRow.jsx
@@ -23,7 +23,7 @@ class StrongholdRow extends React.Component {
                     <div className='deck-cards'>
                         { this.props.role && this.props.role.location ? <CardPile className='rolecard' source='role card' cards={ [] } topCard={ this.props.role } disablePopup
                             onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } size={ this.props.cardSize } /> : <Placeholder size={ this.props.cardSize } /> }
-                        <Province isMe={ this.props.isMe } source='stronghold province' cards={ this.props.strongholdProvinceCards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onDragDrop={ this.props.onDragDrop } onCardClick={ this.props.onCardClick } size={ this.props.cardSize } />
+                        <Province isMe={ this.props.isMe } source='stronghold province' cards={ this.props.strongholdProvinceCards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onDragDrop={ this.props.onDragDrop } onCardClick={ this.props.onCardClick } size={ this.props.cardSize } onMenuItemClick={ this.props.onMenuItemClick } />
                         { this.getFavor(this.props.thisPlayer) }
                     </div>
                 </div>
@@ -40,7 +40,7 @@ class StrongholdRow extends React.Component {
                     { (!this.props.isMe && this.props.thisPlayer) ? this.getFavor(this.props.thisPlayer) : this.getFavor(this.props.otherPlayer) }
                     <Province isMe={ this.props.isMe } source='stronghold province' cards={ this.props.strongholdProvinceCards } onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } size={ this.props.cardSize } />
                     { this.props.role && this.props.role.location ? <CardPile className='rolecard' source='role card' cards={ [] } topCard={ this.props.role } disablePopup
-                        onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } size={ this.props.cardSize } /> : '' }
+                        onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick } size={ this.props.cardSize } onMenuItemClick={ this.props.onMenuItemClick } /> : '' }
                 </div>
             </div>
         );
@@ -54,6 +54,7 @@ StrongholdRow.propTypes = {
     isMe: PropTypes.bool,
     onCardClick: PropTypes.func,
     onDragDrop: PropTypes.func,
+    onMenuItemClick: PropTypes.func,
     onMouseOut: PropTypes.func,
     onMouseOver: PropTypes.func,
     otherPlayer: PropTypes.object,

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -344,13 +344,20 @@ class BaseCard {
     getMenu() {
         var menu = [];
 
-        if(this.menu.isEmpty()) {
+        if(this.menu.isEmpty() || !this.game.manualMode || 
+                !['province 1', 'province 2', 'province 3', 'province 4', 'stronghold province','play area'].includes(this.location)) {
             return undefined;
+        }
+        
+        if(this.facedown) {
+            return [{ command: 'reveal', text: 'Reveal' }];
         }
 
         menu.push({ command: 'click', text: 'Select Card' });
-        menu = menu.concat(this.menu.value());
-
+        if(this.location === 'play area' || this.isProvince || this.isStronghold) {
+            menu = menu.concat(this.menu.value());
+        }
+        
         return menu;
     }
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -53,6 +53,16 @@ class DrawCard extends BaseCard {
         };
         this.covertLimit = 1;
 
+        this.menu = _([
+            { command: 'bow', text: 'Bow/Ready' },
+            { command: 'honor', text: 'Honor' },
+            { command: 'dishonor', text: 'Dishonor' },
+            { command: 'addfate', text: 'Add 1 fate' },
+            { command: 'remfate', text: 'Remove 1 fate' },
+            { command: 'move', text: 'Move into/out of conflict' },
+            { command: 'control', text: 'Give control' }
+        ]);
+
         if(cardData.side === 'conflict') {
             this.isConflict = true;
         } else if(cardData.side === 'dynasty') {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -345,14 +345,14 @@ class Player extends Spectator {
     }
 
     shuffleConflictDeck() {
-        if(this.user) {
+        if(!this.name === 'Dummy Player') {
             this.game.addMessage('{0} is shuffling their conflict deck', this);
         }
         this.conflictDeck = _(this.conflictDeck.shuffle());
     }
 
     shuffleDynastyDeck() {
-        if(this.user) {
+        if(!this.name === 'Dummy Player') {
             this.game.addMessage('{0} is shuffling their dynasty deck', this);
         }
         this.dynastyDeck = _(this.dynastyDeck.shuffle());

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -345,12 +345,16 @@ class Player extends Spectator {
     }
 
     shuffleConflictDeck() {
-        this.game.addMessage('{0} is shuffling their conflict deck', this);
+        if(this.user) {
+            this.game.addMessage('{0} is shuffling their conflict deck', this);
+        }
         this.conflictDeck = _(this.conflictDeck.shuffle());
     }
 
     shuffleDynastyDeck() {
-        this.game.addMessage('{0} is shuffling their dynasty deck', this);
+        if(this.user) {
+            this.game.addMessage('{0} is shuffling their dynasty deck', this);
+        }
         this.dynastyDeck = _(this.dynastyDeck.shuffle());
     }
 

--- a/server/game/provincecard.js
+++ b/server/game/provincecard.js
@@ -9,6 +9,7 @@ class ProvinceCard extends BaseCard {
         this.strengthModifier = 0;
         this.isProvince = true;
         this.isBroken = false;
+        this.menu = _([{ command: 'break', text: 'Break/unbreak this province' }, { command: 'hide', text: 'Flip face down' }]);
     }
 
     getStrength() {

--- a/server/game/ring.js
+++ b/server/game/ring.js
@@ -1,12 +1,25 @@
+const _ = require('underscore');
 
 class Ring {
-    constructor(element, type) {
+    constructor(game, element, type) {
+        this.game = game;
         this.claimed = false;
         this.claimedBy = '';
         this.conflictType = type;
         this.contested = false;
         this.element = element;
         this.fate = 0;
+        
+        this.menu = _([
+            { command: 'flip', text: 'Flip' },
+            { command: 'claim', text: 'Claim' },
+            { command: 'contested', text: 'Switch this ring to contested' },
+            { command: 'unclaimed', text: 'Set to unclaimed' },
+            { command: 'addfate', text: 'Add 1 fate' },
+            { command: 'remfate', text: 'Remove 1 fate' },
+            { command: 'takefate', text: 'Take all fate' },
+            { command: 'conflict', text: 'Initiate Conflict' }
+        ]);
 
     }
 
@@ -24,6 +37,19 @@ class Ring {
 
     getFate() {
         return this.fate;
+    }
+
+    getMenu() {
+        var menu = [];
+
+        if(this.menu.isEmpty() || !this.game.manualMode) { 
+            return undefined;
+        }
+        
+        menu.push({ command: 'click', text: 'Select Ring' });
+        menu = menu.concat(this.menu.value());
+        
+        return menu;
     }
 
     modifyFate(fate) {
@@ -67,7 +93,8 @@ class Ring {
             conflictType: this.conflictType,
             contested: this.contested,
             element: this.element,
-            fate: this.fate
+            fate: this.fate,
+            menu: this.getMenu()
         };
 
         return state;

--- a/server/game/strongholdcard.js
+++ b/server/game/strongholdcard.js
@@ -10,6 +10,7 @@ class StrongholdCard extends BaseCard {
         this.fateModifier = 0;
         this.honorModifier = 0;
         this.influenceModifier = 0;
+        this.menu = _([{ command: 'bow', text: 'Bow/Ready' }]);
 
         this.isStronghold = true;
     }

--- a/server/settings.js
+++ b/server/settings.js
@@ -1,10 +1,10 @@
 const defaultWindows = {
     dynasty: true,
-    draw: true,
+    draw: false,
     preConflict: true,
     conflict: true,
-    fate: true,
-    regroup: true
+    fate: false,
+    regroup: false
 };
 
 const defaultKeywordSettings = {


### PR DESCRIPTION
- when the game is in manual mode, clicking a card in play area or provinces will trigger a menu which allows you to access most of the functions which you normally access using chat commands
- Also in manual mode, clicking a ring will give you a menu which allows easier access to functions from chat commands, but also lets you flip a ring to change the conflict type, change the contested ring during a conflict, or initiate a new conflict from a pre-conflict action window