### PR TITLE
Change Keyword to Options & add automatic Dynasty flips

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -344,8 +344,8 @@ export class InnerGameBoard extends React.Component {
         this.props.sendGameMessage('toggleTimerSetting', option, value);
     }
 
-    onKeywordSettingToggle(option, value) {
-        this.props.sendGameMessage('toggleKeywordSetting', option, value);
+    onOptionSettingToggle(option, value) {
+        this.props.sendGameMessage('toggleOptionSetting', option, value);
     }
 
     onTimerExpired() {
@@ -485,7 +485,7 @@ export class InnerGameBoard extends React.Component {
                         </div>
                         <div className='modal-body col-xs-12'>
                             <GameConfiguration actionWindows={ thisPlayer.promptedActionWindows } timerSettings={ thisPlayer.timerSettings }
-                                keywordSettings={ thisPlayer.keywordSettings } onKeywordSettingToggle={ this.onKeywordSettingToggle.bind(this) }
+                                optionSettings={ thisPlayer.optionSettings } onOptionSettingToggle={ this.onOptionSettingToggle.bind(this) }
                                 onToggle={ this.onPromptedActionWindowToggle.bind(this) } onTimerSettingToggle={ this.onTimerSettingToggle.bind(this) }
                             />
                         </div>

--- a/client/GameComponents/GameConfiguration.jsx
+++ b/client/GameComponents/GameConfiguration.jsx
@@ -52,9 +52,9 @@ class GameConfiguration extends React.Component {
         }
     }
 
-    onKeywordSettingToggle(option, event) {
-        if(this.props.onKeywordSettingToggle) {
-            this.props.onKeywordSettingToggle(option, event.target.checked);
+    onOptionSettingToggle(option, event) {
+        if(this.props.onOptionSettingToggle) {
+            this.props.onOptionSettingToggle(option, event.target.checked);
         }
     }
 
@@ -93,14 +93,14 @@ class GameConfiguration extends React.Component {
                         </div>
                     </div>
                     <div className='panel-title text-center'>
-                        Keywords
+                        Options
                     </div>
                     <div className='panel'>
                         <div className='form-group'>
-                            <Checkbox name='keywordSettings.chooseOrder' noGroup label={ 'Choose order of keywords' } fieldClass='col-sm-6'
-                                onChange={ this.onKeywordSettingToggle.bind(this, 'chooseOrder') } checked={ this.props.keywordSettings.chooseOrder } />
-                            <Checkbox name='keywordSettings.chooseCards' noGroup label={ 'Make keywords optional' } fieldClass='col-sm-6'
-                                onChange={ this.onKeywordSettingToggle.bind(this, 'chooseCards') } checked={ this.props.keywordSettings.chooseCards } />
+                            <Checkbox name='optionSettings.flipDynasty' noGroup label={ 'Automatically flip dynasty cards' } fieldClass='col-sm-6'
+                                onChange={ this.onOptionSettingToggle.bind(this, 'flipDynasty') } checked={ this.props.optionSettings.flipDynasty } />
+                            <Checkbox name='optionSettings.cancelOwnAbilites' noGroup label={ 'Prompt to cancel my own abilities' } fieldClass='col-sm-6'
+                                onChange={ this.onOptionSettingToggle.bind(this, 'cancelOwnAbilites') } checked={ this.props.optionSettings.chooseCards } />
                         </div>
                     </div>
                 </form>
@@ -112,10 +112,10 @@ class GameConfiguration extends React.Component {
 GameConfiguration.displayName = 'GameConfiguration';
 GameConfiguration.propTypes = {
     actionWindows: PropTypes.object,
-    keywordSettings: PropTypes.object,
-    onKeywordSettingToggle: PropTypes.func,
+    onOptionSettingToggle: PropTypes.func,
     onTimerSettingToggle: PropTypes.func,
     onToggle: PropTypes.func,
+    optionSettings: PropTypes.object,
     timerSettings: PropTypes.object
 };
 

--- a/client/Profile.jsx
+++ b/client/Profile.jsx
@@ -28,7 +28,7 @@ class InnerProfile extends React.Component {
             promptedActionWindows: this.props.user.promptedActionWindows,
             validation: {},
             windowTimer: this.props.user.settings.windowTimer,
-            keywordSettings: this.props.user.settings.keywordSettings,
+            optionSettings: this.props.user.settings.optionSettings,
             timerSettings: this.props.user.settings.timerSettings,
             selectedBackground: this.props.user.settings.background,
             selectedCardSize: this.props.user.settings.cardSize
@@ -79,11 +79,11 @@ class InnerProfile extends React.Component {
         this.setState(newState);
     }
 
-    onKeywordSettingToggle(field, event) {
+    onOptionSettingToggle(field, event) {
         var newState = {};
-        newState.keywordSettings = this.state.keywordSettings;
+        newState.optionSettings = this.state.optionSettings;
 
-        newState.keywordSettings[field] = event.target.checked;
+        newState.optionSettings[field] = event.target.checked;
         this.setState(newState);
     }
 
@@ -115,7 +115,7 @@ class InnerProfile extends React.Component {
                         settings: {
                             disableGravatar: this.state.disableGravatar,
                             windowTimer: this.state.windowTimer,
-                            keywordSettings: this.state.keywordSettings,
+                            optionSettings: this.state.optionSettings,
                             timerSettings: this.state.timerSettings,
                             background: this.state.selectedBackground,
                             cardSize: this.state.selectedCardSize
@@ -253,7 +253,7 @@ class InnerProfile extends React.Component {
                             </div>
                             <div className='panel'>
                                 <p className='help-block small'>Every time a game event occurs that you could possibly interrupt to cancel it, a timer will count down.  At the end of that timer, the window will automatically pass.
-                                This option controls the duration of the timer.  The timer can be configure to show when events are played (useful if you play cards like The Hand's Judgement) and to show when card abilities are triggered (useful if you play a lot of Treachery).</p>
+                                This option controls the duration of the timer.  The timer will only show when you *don't* have an ability which can be used. The timer can be configure to show when events are played (useful if you play cards like Voice of Honor) and to show when card abilities are triggered.</p>
                                 <div className='form-group'>
                                     <label className='col-sm-3 control-label'>Window timeout</label>
                                     <div className='col-sm-5'>
@@ -275,14 +275,14 @@ class InnerProfile extends React.Component {
                                 </div>
                             </div>
                             <div className='panel-title'>
-                                Keywords
+                                Options
                             </div>
                             <div className='panel'>
                                 <div className='form-group'>
-                                    <Checkbox name='keywordSettings.chooseOrder' noGroup label={ 'Choose order of keywords' } fieldClass='col-sm-6'
-                                        onChange={ this.onKeywordSettingToggle.bind(this, 'chooseOrder') } checked={ this.state.keywordSettings.chooseOrder } />
-                                    <Checkbox name='keywordSettings.chooseCards' noGroup label={ 'Make keywords optional' } fieldClass='col-sm-6'
-                                        onChange={ this.onKeywordSettingToggle.bind(this, 'chooseCards') } checked={ this.state.keywordSettings.chooseCards } />
+                                    <Checkbox name='optionSettings.flipDynasty' noGroup label={ 'Automatically flip dynasty cards' } fieldClass='col-sm-6'
+                                        onChange={ this.onOptionSettingToggle.bind(this, 'flipDynasty') } checked={ this.state.optionSettings.flipDynasty } />
+                                    <Checkbox name='optionSettings.cancelOwnAbilites' noGroup label={ 'Prompt to cancel my own abilities' } fieldClass='col-sm-6'
+                                        onChange={ this.onOptionSettingToggle.bind(this, 'cancelOwnAbilites') } checked={ this.state.optionSettings.chooseCards } />
                                 </div>
                             </div>
                         </div>

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -721,13 +721,13 @@ class Game extends EventEmitter {
         player.timerSettings[settingName] = toggle;
     }
 
-    toggleKeywordSetting(playerName, settingName, toggle) {
+    toggleOptionSetting(playerName, settingName, toggle) {
         var player = this.getPlayerByName(playerName);
         if(!player) {
             return;
         }
 
-        player.keywordSettings[settingName] = toggle;
+        player.optionSettings[settingName] = toggle;
     }
 
     initialise() {

--- a/server/game/gamesteps/dynastyphase.js
+++ b/server/game/gamesteps/dynastyphase.js
@@ -20,29 +20,23 @@ class DynastyPhase extends Phase {
         super(game, 'dynasty');
         this.initialise([
             new SimpleStep(game, () => this.beginDynasty()),
-            new SimpleStep(game, () => this.cyclePlayers()),
+            new SimpleStep(game, () => this.flipDynastyCards()),
             new SimpleStep(game, () => this.dynastyActionWindowStep())
         ]);
     }
 
     beginDynasty() {
-        this.allPlayers = this.game.getPlayersInFirstPlayerOrder();
-        this.remainingPlayers = this.allPlayers;
-
-        _.each(this.allPlayers, player => {
+        _.each(this.game.getPlayersInFirstPlayerOrder(), player => {
             player.beginDynasty();
         });
-
     }
 
-    cyclePlayers () {
-
-        if(typeof this.currentPlayer === 'undefined') {
-            //Get First Player
-            this.currentPlayer = this.remainingPlayers.shift();
-        }
-
-
+    flipDynastyCards () {
+        _.each(this.game.getPlayersInFirstPlayerOrder(), player => {
+            if(player.optionSettings['flipDynasty']) {
+                player.flipDynastyCards();
+            }
+        });
     }
 
     dynastyActionWindowStep() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -73,7 +73,7 @@ class Player extends Spectator {
         };
         this.timerSettings = user.settings.timerSettings || {};
         this.timerSettings.windowTimer = user.settings.windowTimer;
-        this.keywordSettings = user.settings.keywordSettings;
+        this.optionSettings = user.settings.optionSettings;
 
         this.createAdditionalPile('out of game', { title: 'Out of Game', area: 'player row' });
 
@@ -186,6 +186,18 @@ class Player extends Spectator {
                 this.moveCard(this.dynastyDeck.first(), province);
             }
         });
+    }
+    
+    flipDynastyCards() {
+        let revealedCards = [];
+        _.each(['province 1', 'province 2', 'province 3', 'province 4'], province => {
+            let card = this.getDynastyCardInProvince(province);
+            if(card) {
+                card.facedown = false;
+                revealedCards.push(card);
+            }
+        });
+        this.game.addMessage('{0} reveals {1}', this, revealedCards);
     }
     
     getDynastyCardInProvince(location) {
@@ -1504,7 +1516,7 @@ class Player extends Spectator {
             faction: this.faction,
             firstPlayer: this.firstPlayer,
             id: this.id,
-            keywordSettings: this.keywordSettings,
+            optionSettings: this.optionSettings,
             imperialFavor: this.imperialFavor,
             left: this.left,
             name: this.name,

--- a/server/settings.js
+++ b/server/settings.js
@@ -7,9 +7,9 @@ const defaultWindows = {
     regroup: false
 };
 
-const defaultKeywordSettings = {
-    chooseOrder: false,
-    chooseCards: false
+const defaultOptionSettings = {
+    flipDynasty: true,
+    cancelOwnAbilites: false
 };
 
 const defaultSettings = {
@@ -31,7 +31,7 @@ function getUserWithDefaultsSet(user) {
     }
 
     userToReturn.settings = Object.assign({}, defaultSettings, userToReturn.settings);
-    userToReturn.settings.keywordSettings = Object.assign({}, defaultKeywordSettings, userToReturn.settings.keywordSettings);
+    userToReturn.settings.optionSettings = Object.assign({}, defaultOptionSettings, userToReturn.settings.optionSettings);
     userToReturn.settings.timerSettings = Object.assign({}, defaultTimerSettings, userToReturn.settings.timerSettings);
     userToReturn.permissions = Object.assign({}, userToReturn.permissions);
     userToReturn.promptedActionWindows = Object.assign({}, defaultWindows, userToReturn.promptedActionWindows);


### PR DESCRIPTION
The profile and game settings menu now have an option section where you can get the game to flip cards for you automatically at the start of the Dynasty phase