### PR TITLE
Refactor context.targets for AbilityResolver

### DIFF
--- a/server/game/AbilityTargets/AbilityTargetCard.js
+++ b/server/game/AbilityTargets/AbilityTargetCard.js
@@ -15,7 +15,7 @@ class AbilityTargetCard {
 
     resolve(context, pretarget = false, noCostsFirstButton = false) {
         let otherProperties = _.omit(this.properties, 'cardCondition');
-        let result = { resolved: false, name: this.name, value: null, costsFirst: false };
+        let result = { resolved: false, name: this.name, value: null, costsFirst: false, mode: this.properties.mode };
         let player = context.player;
         if(this.properties.player && this.properties.player === 'opponent') {
             if(pretarget) {

--- a/server/game/AbilityTargets/AbilityTargetRing.js
+++ b/server/game/AbilityTargets/AbilityTargetRing.js
@@ -11,7 +11,7 @@ class AbilityTargetCard {
     }
 
     resolve(context, pretarget = false, noCostsFirstButton = false) {
-        let result = { resolved: false, name: this.name, value: null, costsFirst: false };
+        let result = { resolved: false, name: this.name, value: null, costsFirst: false, mode: 'ring' };
         let player = context.player;
         if(this.properties.player && this.properties.player === 'opponent') {
             if(pretarget) {

--- a/server/game/AbilityTargets/AbilityTargetSelect.js
+++ b/server/game/AbilityTargets/AbilityTargetSelect.js
@@ -11,7 +11,7 @@ class AbilityTargetSelect {
     }
 
     resolve(context, pretarget = false, noCostsFirstButton = false) {
-        let result = { resolved: false, name: this.name, value: null, costsFirst: false };
+        let result = { resolved: false, name: this.name, value: null, costsFirst: false, mode: 'select' };
         let player = context.player;
         if(this.properties.player && this.properties.player === 'opponent') {
             if(pretarget) {

--- a/server/game/cards/01-Core/CourtGames.js
+++ b/server/game/cards/01-Core/CourtGames.js
@@ -18,7 +18,7 @@ class CourtGames extends DrawCard {
                 }
             },
             handler: context => {
-                if(context.target === 'Honor a character you control') {
+                if(context.select === 'Honor a character you control') {
                     this.game.promptForSelect(this.controller, {
                         cardType: 'character',
                         cardCondition: card => card.isParticipating() && card.controller === this.controller && card.allowGameAction('honor', context),

--- a/server/game/cards/01-Core/IdeTrader.js
+++ b/server/game/cards/01-Core/IdeTrader.js
@@ -8,20 +8,22 @@ class IdeTrader extends DrawCard {
                 onMoveCharactersToConflict: () => this.isParticipating()
             },
             limit: ability.limit.perConflict(1),
-            handler: () => this.game.promptWithHandlerMenu(this.controller, {
-                source: this,
-                choices: ['Gain 1 fate', 'Draw 1 card'],
-                handlers: [
-                    () => {
-                        this.game.addMessage('{0} uses {1} to gain 1 fate', this.controller, this);
-                        this.game.addFate(this.controller, 1);
-                    },
-                    () => {
-                        this.game.addMessage('{0} uses {1} to draw 1 card', this.controller, this);
-                        this.controller.drawCardsToHand(1);
-                    }
-                ]
-            })
+            target: {
+                mode: 'select',
+                choices: {
+                    'Gain 1 fate': () => true,
+                    'Draw 1 card': () => true
+                }
+            },
+            handler: context => {
+                if(context.select === 'Gain 1 fate') {
+                    this.game.addMessage('{0} uses {1} to gain 1 fate', this.controller, this);
+                    this.game.addFate(this.controller, 1);
+                } else {
+                    this.game.addMessage('{0} uses {1} to draw 1 card', this.controller, this);
+                    this.controller.drawCardsToHand(1);
+                }
+            }
         });
     }
 }

--- a/server/game/cards/01-Core/KuroiMori.js
+++ b/server/game/cards/01-Core/KuroiMori.js
@@ -16,7 +16,7 @@ class KuroiMori extends ProvinceCard {
             },
             source: this,
             handler: context => {
-                if(context.target === 'Switch the contested ring') {
+                if(context.select === 'Switch the contested ring') {
                     this.game.promptForRingSelect(this.controller, {
                         ringCondition: ring => !ring.contested && !ring.claimed,
                         onSelect: (player, ring) => {

--- a/server/game/cards/01-Core/Levy.js
+++ b/server/game/cards/01-Core/Levy.js
@@ -13,7 +13,7 @@ class Levy extends DrawCard {
                 }
             },
             handler: context => {
-                if(context.target === 'Give your opponent 1 fate') {
+                if(context.select === 'Give your opponent 1 fate') {
                     this.game.addMessage('{0} uses {1} to take 1 fate from {2}', this.controller, this, this.controller.opponent);
                     this.game.transferFate(this.controller, this.controller.opponent, 1);
                 } else {

--- a/server/game/cards/01-Core/MeddlingMediator.js
+++ b/server/game/cards/01-Core/MeddlingMediator.js
@@ -4,7 +4,7 @@ class MeddlingMediator extends DrawCard {
     setupCardAbilities() {
         this.action({
             title: 'Take 1 fate or 1 honor',
-            condition: () => this.controller.opponent.conflicts.complete > 1,
+            condition: () => this.controller.opponent && this.controller.opponent.conflicts.complete > 1,
             target: {
                 mode: 'select',
                 choices: {
@@ -13,7 +13,7 @@ class MeddlingMediator extends DrawCard {
                 }
             },
             handler: context => {
-                if(context.target === 'Take 1 fate') {
+                if(context.select === 'Take 1 fate') {
                     this.game.addMessage('{0} uses {1} to take 1 fate from {2}', this.controller, this, this.controller.opponent);
                     this.game.transferFate(this.controller, this.controller.opponent, 1);
                 } else {

--- a/server/game/cards/01-Core/ShibaYojimbo.js
+++ b/server/game/cards/01-Core/ShibaYojimbo.js
@@ -6,7 +6,7 @@ class ShibaYojimbo extends DrawCard {
         this.interrupt({
             title: 'Cancel ability',
             when: {
-                onCardAbilityInitiated: event => _.any(_.reject(event.targets, target => _.isString(target) || target.type === 'ring'), card => card.hasTrait('shugenja') && card.controller === this.controller)
+                onCardAbilityInitiated: event => _.any(event.targets, card => card.hasTrait('shugenja') && card.controller === this.controller)
             },
             canCancel: true,
             handler: context => {

--- a/server/game/cards/01-Core/ShosuroMiyako.js
+++ b/server/game/cards/01-Core/ShosuroMiyako.js
@@ -21,7 +21,7 @@ class ShosuroMiyako extends DrawCard {
                 }
             },
             handler: context => {
-                if(context.target === 'Discard at random') {
+                if(context.select === 'Discard at random') {
                     this.game.addMessage('{0} uses {1} - {2} chose to discard a card at random', this.controller, this, this.controller.opponent);
                     this.controller.opponent.discardAtRandom(1);
                 } else {

--- a/server/game/cards/01-Core/WayOfThePhoenix.js
+++ b/server/game/cards/01-Core/WayOfThePhoenix.js
@@ -11,8 +11,8 @@ class WayOfThePhoenix extends DrawCard {
                 ringCondition: () => true
             },
             handler: context => {
-                let elements = [context.target.element];
-                if(this.game.currentConflict && this.game.currentConflict.conflictRing === context.target.element) {
+                let elements = [context.ring.element];
+                if(this.game.currentConflict && this.game.currentConflict.conflictRing === context.ring.element) {
                     elements = this.game.currentConflict.getElements();
                 }
                 let otherPlayer = this.game.getOtherPlayer(context.player);

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -75,7 +75,7 @@ class AbilityResolver extends BaseStepWithPipeline {
 
         if(this.context.ability.cannotTargetFirst) {
             this.targetResults = _.map(this.context.ability.targets, (props, name) => {
-                return { resolved: false, name: name, value: null, costsFirst: true };
+                return { resolved: false, name: name, value: null, costsFirst: true, mode: props.mode };
             });
         } else {
             this.targetResults = this.context.ability.resolveTargets(this.context);
@@ -102,9 +102,21 @@ class AbilityResolver extends BaseStepWithPipeline {
         }
 
         _.each(this.targetResults, result => {
-            this.context.targets[result.name] = result.value;
-            if(result.name === 'target') {
-                this.context.target = result.value;
+            if(result.mode === 'ring') {
+                this.context.rings[result.name] = result.value;
+                if(result.name === 'target') {
+                    this.context.ring = result.value;
+                }
+            } else if(result.mode === 'select') {
+                this.context.selects[result.name] = result.value;
+                if(result.name === 'target') {
+                    this.context.select = result.value;
+                }
+            } else {
+                this.context.targets[result.name] = result.value;
+                if(result.name === 'target') {
+                    this.context.target = result.value;
+                }
             }
         });
     }

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -138,7 +138,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
                 controls.push({
                     type: 'targeting',
                     source: event.source.getShortSummary(),
-                    targets: event.targets.map(target => _.isString(target) ? target : target.getShortSummary())
+                    targets: event.targets.map(target => target.getShortSummary())
                 });
             }
         }

--- a/test/server/card/baseability.spec.js
+++ b/test/server/card/baseability.spec.js
@@ -247,8 +247,8 @@ describe('BaseAbility', function () {
             this.player = { player: 1 };
             this.source = { source: 1 };
 
-            this.target1 = { target: 1 };
-            this.target2 = { target: 2 };
+            this.target1 = { target: 1, mode: 'single' };
+            this.target2 = { target: 2, mode: 'single' };
 
             this.properties.targets = { target1: this.target1, target2: this.target2 };
             this.ability = new BaseAbility(this.properties);
@@ -257,7 +257,7 @@ describe('BaseAbility', function () {
         });
 
         it('should return target results for each target', function() {
-            expect(this.ability.resolveTargets(this.context)).toEqual([{ resolved: false, name: 'target1', value: null, costsFirst: false }, { resolved: false, name: 'target2', value: null, costsFirst: false }]);
+            expect(this.ability.resolveTargets(this.context)).toEqual([{ resolved: false, name: 'target1', value: null, costsFirst: false, mode: 'single' }, { resolved: false, name: 'target2', value: null, costsFirst: false, mode: 'single' }]);
         });
 
         it('should prompt the player to select each target', function() {

--- a/test/server/card/baseability.spec.js
+++ b/test/server/card/baseability.spec.js
@@ -262,8 +262,8 @@ describe('BaseAbility', function () {
 
         it('should prompt the player to select each target', function() {
             this.ability.resolveTargets(this.context);
-            expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.player, { source: this.source, target: 1, onSelect: jasmine.any(Function), onCancel: jasmine.any(Function), selector: jasmine.any(Object), context: this.context, waitingPromptTitle: jasmine.any(String), buttons: jasmine.any(Array), onMenuCommand: jasmine.any(Function), pretarget: true });
-            expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.player, { source: this.source, target: 1, onSelect: jasmine.any(Function), onCancel: jasmine.any(Function), selector: jasmine.any(Object), context: this.context, waitingPromptTitle: jasmine.any(String), buttons: jasmine.any(Array), onMenuCommand: jasmine.any(Function), pretarget: true });
+            expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.player, { source: this.source, target: 1, onSelect: jasmine.any(Function), onCancel: jasmine.any(Function), selector: jasmine.any(Object), context: this.context, waitingPromptTitle: jasmine.any(String), buttons: jasmine.any(Array), onMenuCommand: jasmine.any(Function), pretarget: true, mode: 'single' });
+            expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.player, { source: this.source, target: 1, onSelect: jasmine.any(Function), onCancel: jasmine.any(Function), selector: jasmine.any(Object), context: this.context, waitingPromptTitle: jasmine.any(String), buttons: jasmine.any(Array), onMenuCommand: jasmine.any(Function), pretarget: true, mode: 'single' });
         });
 
         describe('the select prompt', function() {


### PR DESCRIPTION
The context object for AbilityResolver has an issue in that most code expects targets to be BaseCard objects.  However, in L5R some cards require a 'select' choice or choosing a ring during targeting.  At the moment, they are all stored in context.targets, but this causes bugs and a lot of ugly code.

Solution: add context.rings and context.selects to store rings and select choices respectively.  I've also created a context.ring and context.select which serve the same purpose that context.target does for cards.

Still to do: This breaks the prompt controls for cancel abilities.  Cards which target rings or have 'select' choices will no longer display those choices.