### PR TITLE
Add an EffectSource class

### DIFF
--- a/client/GameComponents/AbilityTargeting.jsx
+++ b/client/GameComponents/AbilityTargeting.jsx
@@ -46,9 +46,10 @@ class AbilityTargeting extends React.Component {
         let targetCards = _.map(this.props.targets, target => {
             return target.type === 'select' ? this.renderStringChoice(target.name) : target.type === 'ring' ? this.renderSimpleRing(target) : this.renderSimpleCard(target);
         });
+        let source = this.props.source.type ? (this.props.source.type === 'ring' ? this.renderSimpleRing(this.props.source) : this.renderSimpleCard(this.props.source)) :  this.renderStringChoice(this.props.source.name)
         return (
             <div className='prompt-control-targeting'>
-                { this.renderSimpleCard(this.props.source) }
+                { source }
                 <span className='glyphicon glyphicon-arrow-right targeting-arrow' />
                 { targetCards }
             </div>);

--- a/server/game/AbilityContext.js
+++ b/server/game/AbilityContext.js
@@ -1,9 +1,10 @@
 const BaseAbility = require('./baseability.js');
+const EffectSource = require('./EffectSource.js');
 
 class AbilityContext {
     constructor(properties) {
         this.game = properties.game;
-        this.source = properties.source || {};
+        this.source = properties.source || new EffectSource();
         this.player = properties.player;
         this.ability = properties.ability || new BaseAbility({});
         this.costs = {};

--- a/server/game/EffectSource.js
+++ b/server/game/EffectSource.js
@@ -1,0 +1,58 @@
+class EffectSource {
+    constructor() {
+        this.name = 'Framework efffect';
+        this.id = this.name;
+        this.factions = {};
+        this.traits = {};
+        this.type = '';
+    }
+
+    isUnique() {
+        return false;
+    }
+
+    isBlank() {
+        return false;
+    }
+
+    getType() {
+        return this.type;
+    }
+
+    getPrintedFaction() {
+        return null;
+    }
+
+    hasKeyword() {
+        return false;
+    }
+
+    hasTrait(trait) {
+        let traitCount = this.traits[trait.toLowerCase()] || 0;
+        return traitCount > 0;
+    }
+
+    getTraits() {
+        return _.keys(_.omit(this.traits, trait => trait < 1));
+    }
+            
+    isFaction(faction) {
+        return !!this.factions[faction.toLowerCase()];
+    }
+            
+    hasToken() {
+        return false;
+    }
+            
+    getShortSummary() {
+        return {
+            id: this.id,
+            label: this.name,
+            name: this.name,
+            type: this.getType()
+        };
+    }
+
+}
+
+module.exports = EffectSource;

--- a/server/game/EffectSource.js
+++ b/server/game/EffectSource.js
@@ -1,6 +1,6 @@
 class EffectSource {
-    constructor() {
-        this.name = 'Framework efffect';
+    constructor(name = 'Framework effect') {
+        this.name = name;
         this.id = this.name;
         this.factions = {};
         this.traits = {};

--- a/server/game/Rings/RingSource.js
+++ b/server/game/Rings/RingSource.js
@@ -1,3 +1,5 @@
+const EffectSource = require('../EffectSource.js');
+
 const capitalize = {
     military: 'Military',
     political: 'Political',
@@ -8,8 +10,9 @@ const capitalize = {
     void: 'Void'
 };
 
-class RingSource {
+class RingSource extends EffectSource {
     constructor(player, ring) {
+        super();
         this.controller = player;
         this.ring = ring;
         this.element = ring.element;
@@ -19,48 +22,6 @@ class RingSource {
         this.factions = {};
         this.type = 'ring';
     }
-
-    isUnique() {
-        return false;
-    }
-
-    isBlank() {
-        return false;
-    }
-
-    getType() {
-        return this.type;
-    }
-
-    getPrintedFaction() {
-        return null;
-    }
-
-    hasKeyword() {
-        return false;
-    }
-
-    hasTrait() {
-        return false;
-    }
-            
-    isFaction() {
-        return false;
-    }
-            
-    hasToken() {
-        return false;
-    }
-            
-    getShortSummary() {
-        return {
-            id: this.id,
-            label: this.name,
-            name: this.name,
-            type: this.getType()
-        };
-    }
-
 }
 
 module.exports = RingSource;

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -8,6 +8,7 @@ const CardForcedReaction = require('./cardforcedreaction.js');
 const CardInterrupt = require('./cardinterrupt.js');
 const CardReaction = require('./cardreaction.js');
 const CustomPlayAction = require('./customplayaction.js');
+const EffectSource = require('./EffectSource.js');
 const EventRegistrar = require('./eventregistrar.js');
 
 const ValidKeywords = [
@@ -21,8 +22,9 @@ const ValidKeywords = [
 ];
 const LocationsWithEventHandling = ['play area', 'province'];
 
-class BaseCard {
+class BaseCard extends EffectSource {
     constructor(owner, cardData) {
+        super();
         this.owner = owner;
         this.controller = owner;
         this.game = this.owner.game;
@@ -65,7 +67,6 @@ class BaseCard {
         this.parseTraits(cardData.traits || '');
         this.setupCardAbilities(AbilityDsl);
 
-        this.factions = {};
         this.addFaction(cardData.clan);
 
         this.isProvince = false;
@@ -257,19 +258,6 @@ class BaseCard {
         return this.printedKeywords.includes(keyword.toLowerCase());
     }
 
-    hasTrait(trait) {
-        let traitCount = this.traits[trait.toLowerCase()] || 0;
-        return traitCount > 0;
-    }
-
-    getTraits() {
-        return _.keys(_.omit(this.traits, trait => trait < 1));
-    }
-
-    isFaction(faction) {
-        return !!this.factions[faction.toLowerCase()];
-    }
-
     applyAnyLocationPersistentEffects() {
         _.each(this.abilities.persistentEffects, effect => {
             if(effect.location === 'any') {
@@ -367,10 +355,6 @@ class BaseCard {
 
     isBlank() {
         return this.blankCount > 0;
-    }
-
-    getType() {
-        return this.type;
     }
 
     getPrintedFaction() {
@@ -504,15 +488,6 @@ class BaseCard {
 
     getProvinceStrengthBonus() {
         return 0;
-    }
-
-    getShortSummary() {
-        return {
-            id: this.cardData.id,
-            label: this.cardData.name,
-            name: this.cardData.name,
-            type: this.getType()
-        };
     }
 
     getSummary(activePlayer, hideWhenFaceup) {

--- a/server/game/cards/01-Core/AsakoDiplomat.js
+++ b/server/game/cards/01-Core/AsakoDiplomat.js
@@ -24,6 +24,7 @@ class AsakoDiplomat extends DrawCard {
                     choices.push('Honor ' + context.target.name);
                     choices.push('Dishonor ' + context.target.name);
                     this.game.promptWithHandlerMenu(this.controller, {
+                        source: this,
                         choices: choices,
                         handlers: [
                             () => {

--- a/server/game/gamesteps/handlermenuprompt.js
+++ b/server/game/gamesteps/handlermenuprompt.js
@@ -1,4 +1,5 @@
 const _ = require('underscore');
+const EffectSource = require('../EffectSource.js');
 const UiPrompt = require('./uiprompt.js');
 
 /**
@@ -20,10 +21,12 @@ class HandlerMenuPrompt extends UiPrompt {
         super(game);
         this.player = player;
         if(_.isString(properties.source)) {
-            properties.source = { name: properties.source };
+            properties.source = new EffectSource(properties.source);
         }
         if(properties.source && !properties.waitingPromptTitle) {
             properties.waitingPromptTitle = 'Waiting for opponent to use ' + properties.source.name;
+        } else if(!properties.source) {
+            properties.source = new EffectSource();
         }
         this.properties = properties;
     }

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -115,6 +115,8 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
                 }
                 this.game.promptWithHandlerMenu(player, {
                     activePromptTitle: 'Which event do you want to respond to?',
+                    source: 'Ability Window',
+                    waitingPromptTitle: 'Waiting for opponent',
                     choices: _.map(cardChoices, abilityChoice => {
                         return TriggeredAbilityWindowTitles.getAction(abilityChoice.context.event);
                     }),


### PR DESCRIPTION
At the moment, cannot and immunity restrictions don't really know what they are being passed in the context object.  In order to unify the logic around these restrictions, I've added an EffectSource class which both cards and rings inherit from.  This allows both restrictions and the targeting UI to call methods on the source object without throwing exceptions.