### PR TITLE
Support 'X. Then, Y' effects

### DIFF
--- a/server/game/Events/Event.js
+++ b/server/game/Events/Event.js
@@ -7,6 +7,9 @@ class Event {
         this.cancelled = false;
         this.handler = handler;
         this.window = null;
+        this.thenEvents = [];
+        this.parentEvent = null;
+        this.result = { resolved: false, success: false};
         this.uuid = uuid.v1();
 
         _.extend(this, params);
@@ -42,7 +45,7 @@ class Event {
     
     executeHandler() {
         if(this.handler) {
-            this.resolved = this.handler(...this.params);
+            this.result = this.handler(...this.params) || { resolved: true, success: true};
         }
     }
 }

--- a/server/game/Events/EventBuilder.js
+++ b/server/game/Events/EventBuilder.js
@@ -1,3 +1,5 @@
+const _ = require('underscore');
+
 const Event = require('./Event');
 const InitiateCardAbilityEvent = require('./InitiateCardAbilityEvent');
 const LeavesPlayEvent = require('./LeavesPlayEvent');
@@ -15,6 +17,16 @@ class EventBuilder {
         let factory = NameToEvent.default;
         if(NameToEvent[name]) {
             factory = NameToEvent[name];
+        }
+
+        if(params.thenEvents) {
+            let thenEvents = _.map(params.thenEvents, event => this.for(event.name, event.params, event.handler));
+            let event = factory(name, _.omit(params, 'thenEvents'), handler);
+            _.each(thenEvents, thenEvent => {
+                thenEvent.parentEvent = event;
+            });
+            event.thenEvents = thenEvents;
+            return event;   
         }
 
         return factory(name, params, handler);

--- a/server/game/conflict.js
+++ b/server/game/conflict.js
@@ -140,7 +140,8 @@ class Conflict {
                 });
             } else {
                 this.resolveConflictRing(player);
-            }        
+            }
+            return { resolved: true, success: true };        
         });
     }
     

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -395,20 +395,26 @@ class DrawCard extends BaseCard {
     honor() {
         if(this.isDishonored) {
             this.isDishonored = false;
+            return true;
         } else if(!this.isHonored) {
             this.isHonored = true;
+            return true;
         }
+        return false;
     }
 
     dishonor() {
         if(!this.allowGameAction('dishonor')) {
-            return;
+            return false;
         }
         if(this.isHonored) {
             this.isHonored = false;
+            return true;
         } else if(!this.isDishonored) {
             this.isDishonored = true;
+            return true;
         }
+        return false;
     }
 
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -24,6 +24,7 @@ const SelectCardPrompt = require('./gamesteps/selectcardprompt.js');
 const SelectRingPrompt = require('./gamesteps/selectringprompt.js');
 const EventBuilder = require('./Events/EventBuilder.js');
 const EventWindow = require('./gamesteps/EventWindow.js');
+const ThenEventWindow = require('./gamesteps/ThenEventWindow.js');
 const InitateAbilityEventWindow = require('./gamesteps/InitiateAbilityEventWindow.js');
 const AbilityResolver = require('./gamesteps/abilityresolver.js');
 const ForcedTriggeredAbilityWindow = require('./gamesteps/forcedtriggeredabilitywindow.js');
@@ -1220,6 +1221,15 @@ class Game extends EventEmitter {
             events = [events];
         }
         this.queueStep(new EventWindow(this, events));
+    }
+
+    openThenEventWindow(events) {
+        if(!_.isArray(events)) {
+            events = [events];
+        }
+        let window = new ThenEventWindow(this, events)
+        this.queueStep(window);
+        return window;
     }
 
     /**

--- a/server/game/gamesteps/DuelFlow.js
+++ b/server/game/gamesteps/DuelFlow.js
@@ -48,7 +48,10 @@ class DuelFlow extends BaseStepWithPipeline {
 
     applyDuelResults() {
         if(this.duel.winner) {
-            this.game.raiseEvent('onDuelResolution', { duel: this.duel }, () => this.resolutionHandler(this.duel.winner, this.duel.loser));
+            this.game.raiseEvent('onDuelResolution', { duel: this.duel }, () => {
+                this.resolutionHandler(this.duel.winner, this.duel.loser);
+                return { resolved: true, success: true };
+            });
         }
     }
 

--- a/server/game/gamesteps/EventWindow.js
+++ b/server/game/gamesteps/EventWindow.js
@@ -1,7 +1,6 @@
 const _ = require('underscore');
 
 const BaseStepWithPipeline = require('./basestepwithpipeline.js');
-const ThenEventWindow = require('./ThenEventWindow.js');
 const SimpleStep = require('./simplestep.js');
 
 class EventWindow extends BaseStepWithPipeline {
@@ -83,8 +82,7 @@ class EventWindow extends BaseStepWithPipeline {
         });
 
         if(thenEvents.length > 0) {
-            let thenEventWindow = new ThenEventWindow(this.game, thenEvents);
-            this.queueStep(thenEventWindow);
+            let thenEventWindow = this.game.openThenEventWindow(thenEvents);
             this.game.queueSimpleStep(() => {
                 _.each(thenEventWindow.events, event => {
                     this.addEvent(event);

--- a/server/game/gamesteps/EventWindow.js
+++ b/server/game/gamesteps/EventWindow.js
@@ -83,12 +83,11 @@ class EventWindow extends BaseStepWithPipeline {
         });
 
         if(thenEvents.length > 0) {
-            this.queueStep(new ThenEventWindow(this.game, thenEvents));
+            let thenEventWindow = new ThenEventWindow(this.game, thenEvents);
+            this.queueStep(thenEventWindow);
             this.game.queueSimpleStep(() => {
-                _.each(thenEvents, event => {
-                    if(!event.cancelled) {
-                        this.addEvent(event);
-                    }
+                _.each(thenEventWindow.events, event => {
+                    this.addEvent(event);
                 });
             });
         }

--- a/server/game/gamesteps/ThenEventWindow.js
+++ b/server/game/gamesteps/ThenEventWindow.js
@@ -1,0 +1,22 @@
+const _ = require('underscore');
+
+const EventWindow = require('./EventWindow.js');
+const SimpleStep = require('./simplestep.js');
+
+class ThenEventWindow extends EventWindow {
+    constructor(game, events) {
+        events = _.filter(events, event => event.parentEvent.result.success);
+        super(game, events);
+    }
+
+    initialise() {
+        this.pipeline.initialise([
+            new SimpleStep(this.game, () => this.openWindow('cancelinterrupt')),
+            new SimpleStep(this.game, () => this.openWindow('forcedinterrupt')),
+            new SimpleStep(this.game, () => this.openWindow('interrupt')),
+            new SimpleStep(this.game, () => this.checkForOtherEffects()),
+            new SimpleStep(this.game, () => this.preResolutionEffects()),
+            new SimpleStep(this.game, () => this.executeHandler())
+        ]);
+    }
+}

--- a/server/game/gamesteps/ThenEventWindow.js
+++ b/server/game/gamesteps/ThenEventWindow.js
@@ -20,3 +20,5 @@ class ThenEventWindow extends EventWindow {
         this.events = _.filter(this.events, event => event.parentEvent.result.success);
     }
 }
+
+module.exports = ThenEventWindow;

--- a/server/game/gamesteps/ThenEventWindow.js
+++ b/server/game/gamesteps/ThenEventWindow.js
@@ -4,13 +4,9 @@ const EventWindow = require('./EventWindow.js');
 const SimpleStep = require('./simplestep.js');
 
 class ThenEventWindow extends EventWindow {
-    constructor(game, events) {
-        events = _.filter(events, event => event.parentEvent.result.success);
-        super(game, events);
-    }
-
     initialise() {
         this.pipeline.initialise([
+            new SimpleStep(this.game, () => this.filterUnsuccessfulEvents()),
             new SimpleStep(this.game, () => this.openWindow('cancelinterrupt')),
             new SimpleStep(this.game, () => this.openWindow('forcedinterrupt')),
             new SimpleStep(this.game, () => this.openWindow('interrupt')),
@@ -18,5 +14,9 @@ class ThenEventWindow extends EventWindow {
             new SimpleStep(this.game, () => this.preResolutionEffects()),
             new SimpleStep(this.game, () => this.executeHandler())
         ]);
+    }
+
+    filterUnsuccessfulEvents() {
+        this.events = _.filter(this.events, event => event.parentEvent.result.success);
     }
 }

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -304,7 +304,10 @@ class ConflictFlow extends BaseStepWithPipeline {
             return;
         }
         if(this.conflict.winner) {
-            this.game.raiseEvent('onClaimRing', { player: this.conflict.winner, conflict: this.conflict }, () => ring.claimRing(this.conflict.winner));
+            this.game.raiseEvent('onClaimRing', { player: this.conflict.winner, conflict: this.conflict }, () => {
+                ring.claimRing(this.conflict.winner);
+                return { resolved: true, success: true };
+            });
 
         }
         //Do this lazily for now

--- a/server/game/gamesteps/fatephase.js
+++ b/server/game/gamesteps/fatephase.js
@@ -46,6 +46,7 @@ class FatePhase extends Phase {
     placeFateOnUnclaimedRings() {
         this.game.raiseEvent('onPlaceFateOnUnclaimedRings', {}, () => {
             this.game.placeFateOnUnclaimedRings();
+            return { resolved: true, success: true };
         });
     }
 }

--- a/server/game/gamesteps/regroupphase.js
+++ b/server/game/gamesteps/regroupphase.js
@@ -34,6 +34,7 @@ class RegroupPhase extends Phase {
             _.each(this.game.getPlayers(), player => {
                 player.readyCards();
             });
+            return { resolved: true, success: true };
         });
     }
     
@@ -93,6 +94,7 @@ class RegroupPhase extends Phase {
     returnRings() {
         this.game.raiseEvent('onReturnRings', {}, () => {
             this.game.returnRings();
+            return { resolved: true, success: true };
         });
     }
 
@@ -100,7 +102,10 @@ class RegroupPhase extends Phase {
         let firstPlayer = this.game.getFirstPlayer();
         let otherPlayer = this.game.getOtherPlayer(firstPlayer);
         if(otherPlayer) {
-            this.game.raiseEvent('onPassFirstPlayer', { player: otherPlayer }, () => this.game.setFirstPlayer(otherPlayer));
+            this.game.raiseEvent('onPassFirstPlayer', { player: otherPlayer }, () => {
+                this.game.setFirstPlayer(otherPlayer);
+                return { resolved: true, success: true };
+            });
         }
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1417,6 +1417,7 @@ class Player extends Spectator {
             } else if(event.card.isDynasty) {
                 this.moveCard(event.card, 'dynasty discard pile');
             }
+            return { resolved: true, success: true };
         });
     }
 
@@ -1625,6 +1626,7 @@ class Player extends Spectator {
                     }
                 }
             }
+            return { resolved: true, success: true };
         });
     }
 
@@ -1634,7 +1636,9 @@ class Player extends Spectator {
      * @param {EffectSource} source 
      */
     honorCard(card, source) {
-        this.game.raiseEvent('onCardHonored', { player: this, card: card, source: source }, () => card.honor());
+        this.game.raiseEvent('onCardHonored', { player: this, card: card, source: source }, () => {
+            return { resolved: true, success: card.honor() };
+        });
     }
 
     /**
@@ -1643,7 +1647,9 @@ class Player extends Spectator {
      * @param {EffectSource} source 
      */
     dishonorCard(card, source) {
-        this.game.raiseEvent('onCardDishonored', { player: this, card: card, source: source }, () => card.dishonor());
+        this.game.raiseEvent('onCardDishonored', { player: this, card: card, source: source }, () => {
+            return { resolved: true, result: card.dishonor() }
+        });
     }
 
     /**


### PR DESCRIPTION
Two of the cards in pack 3 have 'X. Then, Y' effects, and the current EventWindow doesn't really support them.

Then effects have their own interrupt windows, but share reaction windows, so the ThenEventWindow supports this behavior.  EventBuilder now looks for Then events and builds the correct object for them.  This should also allow recursion, so we can support 'X. Then, Y. Then, Z' if they ever print one.