### PR TITLE
Resolve Covert as an ability

### DIFF
--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -186,6 +186,10 @@ class BaseAbility {
     isCardAbility() {
         return false;
     }
+
+    isTriggeredAbility() {
+        return true;
+    }
 }
 
 module.exports = BaseAbility;

--- a/server/game/cards/02.2-FHaG/Kamayari.js
+++ b/server/game/cards/02.2-FHaG/Kamayari.js
@@ -6,7 +6,7 @@ class Kamayari extends DrawCard {
             title: 'Bow character who triggered ability',
             when: {
                 // TODO: Need to check for immunity and cannot restrictions - requires TriggeredAbility to pass context to this function
-                onCardAbilityInitiated: event => event.card.type === 'character' && this.parent.isParticipating() && !event.card.bowed
+                onCardAbilityInitiated: event => event.card.type === 'character' && this.parent.isParticipating() && !event.card.bowed && event.context.ability.isTriggeredAbility()
             },
             handler: context => {
                 this.game.addMessage('{0} uses {1} to bow {2}', this.controller, this, context.event.card);

--- a/server/game/gamesteps/conflict/CovertAbility.js
+++ b/server/game/gamesteps/conflict/CovertAbility.js
@@ -1,0 +1,17 @@
+const BaseAbility = require('../../baseability.js');
+
+class CovertAbility extends BaseAbility {
+    isAction() {
+        return false;
+    }
+
+    isCardAbility() {
+        return true;
+    }
+
+    isTriggeredAbility() {
+        return false;
+    }
+}
+
+module.exports = CovertAbility;

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -1,5 +1,7 @@
 const _ = require('underscore');
+const AbilityContext = require('../../AbilityContext');
 const BaseStepWithPipeline = require('../basestepwithpipeline.js');
+const CovertAbility = require('./CovertAbility');
 const SimpleStep = require('../simplestep.js');
 const ConflictActionWindow = require('../conflictactionwindow.js');
 const InitiateConflictPrompt = require('./initiateconflictprompt.js');
@@ -27,6 +29,8 @@ class ConflictFlow extends BaseStepWithPipeline {
             new SimpleStep(this.game, () => this.resetCards()),
             new InitiateConflictPrompt(this.game, this.conflict, this.conflict.attackingPlayer),
             new SimpleStep(this.game, () => this.initiateConflict()),
+            new SimpleStep(this.game, () => this.resolveCovert()),
+            new SimpleStep(this.game, () => this.raiseDeclarationEvents()),
             new SimpleStep(this.game, () => this.announceAttackerSkill()),
             new SimpleStep(this.game, () => this.promptForDefenders()),
             new SimpleStep(this.game, () => this.announceDefenderSkill()),
@@ -51,16 +55,48 @@ class ConflictFlow extends BaseStepWithPipeline {
             return;
         }
         
-        let events = [{
-            name: 'onConflictDeclared',
-            params: { conflict: this.conflict, conflictType: this.conflict.conflictType, conflictRing: this.conflict.conflictRing }
-        }];
-        
         let ring = this.game.rings[this.conflict.conflictRing];
         ring.contested = true;
         this.conflict.addElement(this.conflict.conflictRing);
         this.conflict.attackingPlayer.conflicts.perform(this.conflict.conflictType);
         _.each(this.conflict.attackers, card => card.inConflict = true);
+        this.game.addMessage('{0} is initiating a {1} conflict at {2}, contesting the {3} ring', this.conflict.attackingPlayer, this.conflict.conflictType, this.conflict.conflictProvince, this.conflict.conflictRing);
+    }
+
+    resolveCovert() {
+        if(this.conflict.cancelled || this.conflict.isSinglePlayer) {
+            return;
+        }
+
+        let targets = this.conflict.defendingPlayer.cardsInPlay.filter(card => card.covert);
+        let sources = _.filter(this.conflict.attackers, card => card.isCovert());
+        if(sources.length > targets.length) {
+            sources = _.first(sources, targets.length);
+        }
+
+        let events = _.map(_.zip(sources, targets), (source, target) => {
+            let context = new AbilityContext({ game: this.game, player: this.conflict.attackingPlayer, source: source, ability: new CovertAbility({}) });
+            context.targets.target = target;
+            return {
+                params: { card: source, context: context },
+                handler: () => target.covert = true
+            };
+        });
+
+        this.game.raiseMultipleInitatiateAbilityEvents(events);
+    }
+
+    raiseDeclarationEvents() {
+        if(this.conflict.cancelled) {
+            return;
+        }
+
+        let events = [{
+            name: 'onConflictDeclared',
+            params: { conflict: this.conflict, conflictType: this.conflict.conflictType, conflictRing: this.conflict.conflictRing }
+        }];
+
+        let ring = this.game.rings[this.conflict.conflictRing];
         if(ring.fate > 0) {
             events.push({
                 name: 'onSelectRingWithFate',
@@ -73,10 +109,9 @@ class ConflictFlow extends BaseStepWithPipeline {
             });
             this.game.addFate(this.conflict.attackingPlayer, ring.fate);
             ring.removeFate();
+            this.game.addMessage('{0} takes {1} fate from the {2} ring', this.conflict.attackingPlayer, ring.fate, this.conflict.conflictRing);
         }
 
-        this.game.addMessage('{0} is initiating a {1} conflict at {2}, contesting the {3} ring', this.conflict.attackingPlayer, this.conflict.conflictType, this.conflict.conflictProvince, this.conflict.conflictRing);
- 
         if(!this.conflict.isSinglePlayer) {
             this.conflict.conflictProvince.inConflict = true;
             if(this.conflict.conflictProvince.facedown) {
@@ -90,6 +125,7 @@ class ConflictFlow extends BaseStepWithPipeline {
                 });
             }
         }
+
         this.game.reapplyStateDependentEffects();
         this.game.raiseMultipleEvents(events);
     }
@@ -110,16 +146,6 @@ class ConflictFlow extends BaseStepWithPipeline {
             onCancel: () => this.conflict.cancelConflict()
         });
     }
-
-    allowAsAttacker(card) {
-        return this.conflict.attackingPlayer === card.controller && card.canDeclareAsAttacker(this.conflict.conflictType);
-    }
-
-    chooseAttackers(player, attackers) {
-        this.conflict.addAttackers(attackers);
-
-        return true;
-    }
     
     announceAttackerSkill() {
         if(this.conflict.cancelled) {
@@ -137,18 +163,6 @@ class ConflictFlow extends BaseStepWithPipeline {
         }
 
         this.game.queueStep(new SelectDefendersPrompt(this.game, this.conflict.defendingPlayer, this.conflict));
-    }
-
-    allowAsDefender(card) {
-        return this.conflict.defendingPlayer === card.controller && card.canDeclareAsDefender(this.conflict.conflictType);
-    }
-
-    chooseDefenders(defenders) {
-        this.conflict.addDefenders(defenders);
-
-        this.game.raiseEvent('onDefendersDeclared', { conflict: this.conflict });
-
-        return true;
     }
 
     announceDefenderSkill() {

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -70,11 +70,13 @@ class ConflictFlow extends BaseStepWithPipeline {
 
         let targets = this.conflict.defendingPlayer.cardsInPlay.filter(card => card.covert);
         let sources = _.filter(this.conflict.attackers, card => card.isCovert());
+        _.each(targets, card => card.covert = false);
         if(sources.length > targets.length) {
             sources = _.first(sources, targets.length);
         }
 
-        let events = _.map(_.zip(sources, targets), (source, target) => {
+        let events = _.map(_.zip(sources, targets), array => {
+            let [source, target] = array;
             let context = new AbilityContext({ game: this.game, player: this.conflict.attackingPlayer, source: source, ability: new CovertAbility({}) });
             context.targets.target = target;
             return {
@@ -83,7 +85,7 @@ class ConflictFlow extends BaseStepWithPipeline {
             };
         });
 
-        this.game.raiseMultipleInitatiateAbilityEvents(events);
+        this.game.raiseMultipleInitiateAbilityEvents(events);
     }
 
     raiseDeclarationEvents() {


### PR DESCRIPTION
This allows Finger of Jade or Shiba Yojimbo to cancel Covert on an appropriate target

Fix for #1026 

There's still a UI issue to be solved with regard to targeting specific characters (e.g. I use Kaiu Shuichi to covert your Doomed Shugenja), however until characters can have immunity to covert, I don't think that's an issue.  Also, the lack of any UI indicator of what ability is being used maybe a future improvement (at the moment, it's 'target sacrifices Finger of Jade to cancel the effect of Kaiu Shuichi', and there's no indication that covert is happening)