### PR TITLE
Implemented Public Forum

### DIFF
--- a/server/game/cards/02.3-ItFC/PublicForum.js
+++ b/server/game/cards/02.3-ItFC/PublicForum.js
@@ -2,9 +2,20 @@ const ProvinceCard = require('../../provincecard.js');
 
 class PublicForum extends ProvinceCard {
     setupCardAbilities(ability) {
+        this.interrupt({
+            when: {
+                onBreakProvince: event => event.province === this && !event.province.hasHonorToken,
+            },
+            canCancel: true,
+            handler: context => {
+                context.cancel();
+                context.event.province.hasHonorToken = true;
+                this.game.addMessage('{0} adds an honor token to {1} instead of breaking it', this.controller, this);
+            }
+        });
     }
 }
 
-PublicForum.id = 'public-forum'; // This is a guess at what the id might be - please check it!!!
+PublicForum.id = 'public-forum';
 
 module.exports = PublicForum;

--- a/server/game/cards/02.3-ItFC/PublicForum.js
+++ b/server/game/cards/02.3-ItFC/PublicForum.js
@@ -4,14 +4,14 @@ class PublicForum extends ProvinceCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onBreakProvince: event => event.province === this && !event.province.hasHonorToken,
+                onBreakProvince: event => event.province === this && !event.province.hasToken('honor'),
             },
             canCancel: true,
             handler: context => {
-                context.cancel();
-                context.event.province.hasHonorToken = true;
                 this.game.addMessage('{0} adds an honor token to {1} instead of breaking it', this.controller, this);
-            }
+                context.cancel();
+                context.event.province.addToken('honor');
+             }
         });
     }
 }

--- a/server/game/provincecard.js
+++ b/server/game/provincecard.js
@@ -9,13 +9,16 @@ class ProvinceCard extends BaseCard {
         this.strengthModifier = 0;
         this.isProvince = true;
         this.isBroken = false;
+        // This is specifically for Public Forum, may want to consider
+        // a list of statuses if this becomes a more common design space
+        this.hasHonorToken = false;
         this.menu = _([{ command: 'break', text: 'Break/unbreak this province' }, { command: 'hide', text: 'Flip face down' }]);
     }
 
     getStrength() {
         return this.cardData.strength + this.strengthModifier + this.getDynastyOrStrongholdCardModifier();
     }
-    
+
     getDynastyOrStrongholdCardModifier() {
         let province = this.controller.getSourceList(this.location);
         let card = province.find(card => card !== this);
@@ -24,7 +27,7 @@ class ProvinceCard extends BaseCard {
         }
         return 0;
     }
-    
+
     getElement() {
         return this.cardData.element;
     }
@@ -41,7 +44,7 @@ class ProvinceCard extends BaseCard {
     flipFaceup() {
         this.facedown = false;
     }
-    
+
     breakProvince() {
         this.isBroken = true;
     }
@@ -52,7 +55,7 @@ class ProvinceCard extends BaseCard {
         }
         return super.canTriggerAbilities();
     }
-    
+
     getSummary(activePlayer, hideWhenFaceup) {
         let baseSummary = super.getSummary(activePlayer, hideWhenFaceup);
 

--- a/server/game/provincecard.js
+++ b/server/game/provincecard.js
@@ -9,9 +9,6 @@ class ProvinceCard extends BaseCard {
         this.strengthModifier = 0;
         this.isProvince = true;
         this.isBroken = false;
-        // This is specifically for Public Forum, may want to consider
-        // a list of statuses if this becomes a more common design space
-        this.hasHonorToken = false;
         this.menu = _([{ command: 'break', text: 'Break/unbreak this province' }, { command: 'hide', text: 'Flip face down' }]);
     }
 


### PR DESCRIPTION
Closes #1069 

I added a hasHonorStatus field to province cards that is only used in the interrupt for Public Forum. It might be smart to at some point turn it into a list of statuses if it seems like this becomes a more popular design space for them.