### PR TITLE
Trigger leaves play effects as a preresolution effect

### DIFF
--- a/server/game/Events/LeavesPlayEvent.js
+++ b/server/game/Events/LeavesPlayEvent.js
@@ -44,12 +44,13 @@ class LeavesPlayEvent extends Event {
     
     preResolutionEffect() {
         this.cardStateWhenLeftPlay = this.card.createSnapshot();
+        // need to do leavesPlayEffects here before any attachments are discarded and we lose their persistent effects
+        this.card.leavesPlayEffects();
     }
 
     leavesPlay() {
-        this.cardStateWhenLeftPlay.leavesPlayEffects(); 
         this.card.owner.moveCard(this.card, this.destination);
-        return true;
+        return { resolved: true, success: true };
     }
 }
 


### PR DESCRIPTION
We need to use the card itself rather than a clone of it for leaves play effects, as the clone isn't affected by any persistent effects which may be in play (e.g. Bayushi Yojiro)