### PR TITLE
Dont reset bid dials when queueing up phases at new round start

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -218,7 +218,7 @@ export class InnerGameBoard extends React.Component {
 
         this.setState({ showDynastyDeck: !this.state.showDynastyDeck });
     }
-    
+
     onConflictTopCardClick() {
         this.props.sendGameMessage('conflictTopCardClicked');
     }
@@ -299,7 +299,7 @@ export class InnerGameBoard extends React.Component {
 
         return cardsByLocation;
     }
-    
+
     onCommand(command, arg, uuid, method) {
         let commandArg = arg;
 
@@ -368,30 +368,30 @@ export class InnerGameBoard extends React.Component {
 
     getProvinces(thisPlayer, otherPlayer) {
         return (<div className='province-pane'>
-            <HonorFan value={ otherPlayer ? otherPlayer.showBid : '0' } />
+            <HonorFan value={ otherPlayer ? otherPlayer.showBid : 0 } />
             <div className='province-group'>
                 <CardPile className={ otherPlayer && otherPlayer.provinceSelected ? 'province-deck province-selected' : 'province-deck' }
-                    title='Province Deck' source='province deck' 
+                    title='Province Deck' source='province deck'
                     cards={ otherPlayer ? otherPlayer.cardPiles.provinceDeck : [] }
                     hiddenTopCard
-                    onMouseOver={ this.onMouseOver } 
-                    onMouseOut={ this.onMouseOut } 
+                    onMouseOver={ this.onMouseOver }
+                    onMouseOut={ this.onMouseOut }
                     disableMouseOver disablePopup
-                    onCardClick={ this.onCardClick } 
+                    onCardClick={ this.onCardClick }
                     size={ this.props.user.settings.cardSize } />
             </div>
             { this.getRings() }
             <div className='province-group our-side'>
                 <CardPile className={ thisPlayer.provinceSelected ? 'province-deck province-selected' : 'province-deck' }
-                    title='Province Deck' source='province deck' 
-                    cards={ thisPlayer.cardPiles.provinceDeck } 
+                    title='Province Deck' source='province deck'
+                    cards={ thisPlayer.cardPiles.provinceDeck }
                     hiddenTopCard
-                    onMouseOver={ this.onMouseOver } 
-                    onMouseOut={ this.onMouseOut } 
-                    onCardClick={ this.onCardClick } 
-                    onDragDrop={ this.onDragDrop } 
+                    onMouseOver={ this.onMouseOver }
+                    onMouseOut={ this.onMouseOut }
+                    onCardClick={ this.onCardClick }
+                    onDragDrop={ this.onDragDrop }
                     disablePopup={ this.state.spectating }
-                    closeOnClick 
+                    closeOnClick
                     size={ this.props.user.settings.cardSize } />
             </div>
             <HonorFan value={ thisPlayer.showBid } />
@@ -435,7 +435,7 @@ export class InnerGameBoard extends React.Component {
         if(!this.props.currentGame) {
             return <div>Waiting for server...</div>;
         }
-        
+
         let manualMode = this.props.currentGame.manualMode;
 
         let thisPlayer = this.props.currentGame.players[this.props.username];
@@ -491,7 +491,7 @@ export class InnerGameBoard extends React.Component {
                         </div>
                     </div>
                 </div>
-            </div>); 
+            </div>);
 
         return (
             <div className='game-board'>
@@ -522,7 +522,7 @@ export class InnerGameBoard extends React.Component {
                                 onConflictTopCardClick={ this.onConflictTopCardClick }
                                 onMouseOver={ this.onMouseOver }
                                 onMouseOut={ this.onMouseOut }
-                                otherPlayer= { otherPlayer } 
+                                otherPlayer= { otherPlayer }
                                 cardSize={ this.props.user.settings.cardSize } />
                         </div>
                         <div className='player-stronghold-row'>
@@ -552,12 +552,12 @@ export class InnerGameBoard extends React.Component {
                                 spectating={ this.state.spectating }
                                 onCardClick={ this.onCardClick }
                                 onDragDrop={ this.onDragDrop }
-                                onMenuItemClick={ this.onMenuItemClick } 
+                                onMenuItemClick={ this.onMenuItemClick }
                                 onMouseOver={ this.onMouseOver }
                                 onMouseOut={ this.onMouseOut }
                                 strongholdProvinceCards={ thisPlayer.strongholdProvince }
                                 role={ thisPlayer.role }
-                                thisPlayer ={ thisPlayer } 
+                                thisPlayer ={ thisPlayer }
                                 cardSize={ this.props.user.settings.cardSize } />
                         </div>
                         <div className='player-deck-row our-side'>
@@ -586,7 +586,7 @@ export class InnerGameBoard extends React.Component {
                                 showDynastyDeck={ this.state.showDynastyDeck }
                                 onDragDrop={ this.onDragDrop }
                                 spectating={ this.state.spectating }
-                                onMenuItemClick={ this.onMenuItemClick } 
+                                onMenuItemClick={ this.onMenuItemClick }
                                 cardSize={ this.props.user.settings.cardSize } />
                         </div>
                     </div>

--- a/client/GameComponents/HonorFan.jsx
+++ b/client/GameComponents/HonorFan.jsx
@@ -64,7 +64,7 @@ HonorFan.propTypes = {
     onMouseOut: PropTypes.func,
     onMouseOver: PropTypes.func,
     socket: PropTypes.object,
-    value: PropTypes.string
+    value: PropTypes.number
 };
 
 export default HonorFan;

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -106,7 +106,7 @@ class Game extends EventEmitter {
     addMessage() {
         this.gameChat.addMessage(...arguments);
     }
-    
+
     /*
      * Adds a message to in-game chat with a graphical icon
      * @param {String} one of: 'endofround', 'success', 'info', 'danger', 'warning'
@@ -121,7 +121,7 @@ class Game extends EventEmitter {
     get messages() {
         return this.gameChat.messages;
     }
-    
+
     /*
      * Checks if a player is a spectator
      * @param {Object} player
@@ -130,7 +130,7 @@ class Game extends EventEmitter {
     isSpectator(player) {
         return player.constructor === Spectator;
     }
-    
+
     /*
      * Checks whether a player/spectator is still in the game
      * @param {String} playerName
@@ -180,7 +180,7 @@ class Game extends EventEmitter {
     getSpectators() {
         return _.pick(this.playersAndSpectators, player => this.isSpectator(player));
     }
-    
+
     /*
      * Gets the current First Player
      * @returns {Player}
@@ -206,7 +206,7 @@ class Game extends EventEmitter {
 
     /*
      * Returns the card (i.e. character) with matching uuid from either players
-     * 'in play' area. 
+     * 'in play' area.
      * @param {String} cardId
      * @returns {DrawCard}
      */
@@ -229,7 +229,7 @@ class Game extends EventEmitter {
     }
 
     /*
-     * Returns all cards (i.e. characters) which matching the passed predicated 
+     * Returns all cards (i.e. characters) which matching the passed predicated
      * function from either players 'in play' area.
      * @param {Function} predicate - card => Boolean
      * @returns {Array} Array of DrawCard objects
@@ -321,9 +321,9 @@ class Game extends EventEmitter {
                 card.facedown = false;
                 this.addMessage('{0} reveals {1}', player, card);
             }
-        }        
+        }
     }
-   
+
     /*
      * This function is called from the client whenever a ring is clicked
      * @param {String} sourcePlayer - name of the clicking player
@@ -337,20 +337,20 @@ class Game extends EventEmitter {
         if(!player || !ring) {
             return;
         }
-        
+
         // Check to see if the current step in the pipeline is waiting for input
         if(this.pipeline.handleRingClicked(player, ring)) {
             return;
         }
-        
+
         // If it's not the conflict phase and the ring hasn't been claimed, flip it
         if(this.currentPhase !== 'conflict' && !ring.claimed) {
             this.flipRing(player, ring);
         }
     }
-    
+
     /*
-     * This function is called from the client whenever the conflict deck is 
+     * This function is called from the client whenever the conflict deck is
      * clicked. It's primary purpose is to support implementation of Arisan
      * Academy
      * @param {String} sourcePlayer - name of the clicking player
@@ -363,9 +363,9 @@ class Game extends EventEmitter {
         if(!player || player.conflictDeckTopCardHidden) {
             return;
         }
-        
+
         let card = player.conflictDeck.first();
-        
+
         // Check to see if the current step in the pipeline is waiting for input
         if(this.pipeline.handleCardClicked(player, card)) {
             return;
@@ -382,7 +382,7 @@ class Game extends EventEmitter {
     returnRings() {
         _.each(this.rings, ring => ring.resetRing());
     }
-    
+
     /*
      * @deprecated
      * @param {type} card
@@ -395,14 +395,14 @@ class Game extends EventEmitter {
         });
     }
 
-    /* 
+    /*
      * Handles clicks on menu commands from in-play cards
      * @deprecated
      * @param {type} card
      * @param {type} player
      * @param {type} menuItem
      * @returns {undefined}
-     * 
+     *
      */
     callCardMenuCommand(card, player, menuItem) {
         if(!card || !card[menuItem.method] || !this.cardHasMenuItem(card, menuItem)) {
@@ -494,7 +494,7 @@ class Game extends EventEmitter {
                 }
                 break;
         }
-        
+
         /* deprecated code
         switch(card.location) {
             case 'province':
@@ -635,7 +635,7 @@ class Game extends EventEmitter {
             this.addMessage('{0} stops looking at their dynasty deck', player);
         }
     }
-    
+
     /*
      * This function is called from the client whenever a card is dragged from
      * one place to another
@@ -734,7 +734,7 @@ class Game extends EventEmitter {
 
     /*
      * Check to see if this player has won/lost the game due to honor (NB: this
-     * function doesn't check to see if a conquest victory has been achieved) 
+     * function doesn't check to see if a conquest victory has been achieved)
      * @param {Player} player
      * @returns {undefined}
      */
@@ -768,7 +768,7 @@ class Game extends EventEmitter {
 
         this.router.gameWon(this, reason, winner);
     }
-    
+
     /*
      * Designate a player as First Player
      * @param {Player} firstPlayer
@@ -809,7 +809,7 @@ class Game extends EventEmitter {
         }
     }
 
-    /* 
+    /*
      * This function is called by the client every time a player enters a chat message
      * @param {String} playerName
      * @param {String} message
@@ -978,7 +978,7 @@ class Game extends EventEmitter {
             return true;
         }
     }
-    
+
     /*
      * This function is called by the client when a player clicks an action window
      * toggle in the settings menu
@@ -1054,7 +1054,7 @@ class Game extends EventEmitter {
                 playerWithNoStronghold = player;
             }
         });
-        
+
         this.allCards = _(_.reduce(this.getPlayers(), (cards, player) => {
             return cards.concat(player.preparedDeck.allCards);
         }, []));
@@ -1210,7 +1210,7 @@ class Game extends EventEmitter {
         return event;
     }
 
-    /* Creates an EventWindow which will open windows for each kind of triggered 
+    /* Creates an EventWindow which will open windows for each kind of triggered
      * ability which can respond any passed events, and execute their handlers.
      * @param {type} events - Array of Event
      * @returns {undefined}
@@ -1246,7 +1246,7 @@ class Game extends EventEmitter {
     }
 
     /**
-     * Raises a custom event window for checking for any cancels to a card 
+     * Raises a custom event window for checking for any cancels to a card
      * ability
      * @param {Object} params
      * @param {Function} handler - this is an arrow function which is called if
@@ -1257,7 +1257,7 @@ class Game extends EventEmitter {
     }
 
     /**
-     * Raises a custom event window for checking for any cancels to several card 
+     * Raises a custom event window for checking for any cancels to several card
      * abilities which initiate simultaneously
      * @param {Array} eventProps
      */
@@ -1286,7 +1286,7 @@ class Game extends EventEmitter {
             return events.concat([conditionalEvent]);
         }
         this.openEventWindow(events);
-        return events;    
+        return events;
     }
 
     /*
@@ -1334,7 +1334,7 @@ class Game extends EventEmitter {
             }
         }
     }
-    
+
     /*
      * Changes the controller of a card in play to the passed player, and cleans
      * all the related stuff up (swapping sides in a conflict, checking for
@@ -1384,7 +1384,7 @@ class Game extends EventEmitter {
         }
         this.raiseEvent('onCardTakenControl', { card: card });
     }
-    
+
     /*
      * Starts a duel between two characters. Prompts for bids, deals with costs
      * of bids, and then resolves the outcome
@@ -1393,7 +1393,7 @@ class Game extends EventEmitter {
      * @param {String} type = 'military' or 'political' // gets the skill to add to bid
      * @param {Function} resolutionHandler - (winner, loser) => undefined //
      * function which deals with any effects due to winning/losing the duel
-     * @param {Function} costHandler - () => undefined // function which resolves 
+     * @param {Function} costHandler - () => undefined // function which resolves
      * costsas a result of bids (transfering honor is the default)
      * @returns {undefined}
      */
@@ -1403,7 +1403,7 @@ class Game extends EventEmitter {
     }
 
     /*
-     * Checks whether a game action can be performed on a card or an array of 
+     * Checks whether a game action can be performed on a card or an array of
      * cards, and performs it on all legal targets.
      * @deprecated
      * @param {String} actionType

--- a/server/game/gamesteps/honorbidprompt.js
+++ b/server/game/gamesteps/honorbidprompt.js
@@ -8,30 +8,31 @@ class HonorBidPrompt extends AllPlayerPrompt {
         this.menuTitle = menuTitle || 'Choose a bid';
         _.each(game.getPlayers(), player => {
             player.honorBid = 0;
-            player.showBid = 0;
         });
     }
-    
+
     activeCondition(player) {
         return player.honorBid === 0;
     }
-    
+
     completionCondition(player) {
         return player.honorBid > 0;
     }
-    
+
     continue() {
         let completed = super.continue();
-        
+
         if(completed) {
             _.each(this.game.getPlayers(), player => player.setShowBid());
             this.game.raiseEvent('onHonorDialsRevealed');
         }
-        
+
         return completed;
     }
 
     activePrompt() {
+        _.each(this.game.getPlayers(), player => player.showBid = 0);
+
         return {
             promptTitle: 'Honor Bid',
             menuTitle: this.menuTitle,
@@ -51,9 +52,9 @@ class HonorBidPrompt extends AllPlayerPrompt {
 
     menuCommand(player, bid) {
         this.game.addMessage('{0} has chosen a bid.', player);
-        
+
         player.honorBid = bid;
-        
+
         return true;
     }
 }


### PR DESCRIPTION
Resolves #1155 

Moved the code resetting visible player bids from the honor prompt constructor (which is ran when starting a new round) to the method called when the prompt is actually shown.
Also fixed a minor property type mismatch for the HonorFan components.