### PR TITLE
Mountaintop Statuary

### DIFF
--- a/server/game/cards/02.4-TCT/MountaintopStatuary.js
+++ b/server/game/cards/02.4-TCT/MountaintopStatuary.js
@@ -1,10 +1,34 @@
 const DrawCard = require('../../drawcard.js');
 
 class MountaintopStatuary extends DrawCard {
-    setupCardAbilities(ability) { // eslint-disable-line no-unused-vars
+    setupCardAbilities(ability) {
+        this.reaction({
+            title: 'Move this to stronghold province',
+            when: {
+                onDynastyCardTurnedFaceup: event => event.card === this
+            },
+            handler: () => {
+                this.game.addMessage('{0} uses {1} to move {1} to their stronghold province', this.controller, this);
+                this.controller.moveCard(this, 'stronghold province');
+            }
+        });
+        this.action({
+            title: 'Send a 2 or lower cost character home',
+            cost: ability.costs.sacrificeSelf(),
+            condition: () => this.game.currentConflict && this.game.currentConflict.conflictProvince === this,
+            target: {
+                cardType: 'character',
+                gameAction: 'sendHome',
+                cardCondition: card => card.isAttacking() && card.getCost() < 3
+            },
+            handler: context => {
+                this.game.addMessage('{0} sacrifices {1} to send {2} home', this.controller, this, context.target);
+                this.game.currentConflict.sendHome(context.target, this);
+            }
+        });
     }
 }
 
-MountaintopStatuary.id = 'mountaintop-statuary'; // This is a guess at what the id might be - please check it!!!
+MountaintopStatuary.id = 'mountaintop-statuary'; 
 
 module.exports = MountaintopStatuary;

--- a/server/game/cards/02.4-TCT/MountaintopStatuary.js
+++ b/server/game/cards/02.4-TCT/MountaintopStatuary.js
@@ -8,14 +8,14 @@ class MountaintopStatuary extends DrawCard {
                 onDynastyCardTurnedFaceup: event => event.card === this
             },
             handler: () => {
-                this.game.addMessage('{0} uses {1} to move {1} to their stronghold province', this.controller, this);
+                this.game.addMessage('{0} uses {1}, moving it to their stronghold province', this.controller, this);
                 this.controller.moveCard(this, 'stronghold province');
             }
         });
         this.action({
             title: 'Send a 2 or lower cost character home',
             cost: ability.costs.sacrificeSelf(),
-            condition: () => this.game.currentConflict && this.game.currentConflict.conflictProvince === this,
+            condition: () => this.game.currentConflict && this.game.currentConflict.conflictProvince && this.game.currentConflict.conflictProvince.location === this.location,
             target: {
                 cardType: 'character',
                 gameAction: 'sendHome',

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -315,13 +315,14 @@ class Game extends EventEmitter {
             return;
         }
 
+        /* This doesn't really work with cards which trigger from being flipped
         // If it's the Dynasty phase, and this is a Dynasty card in a province, flip it face up
         if(['province 1', 'province 2', 'province 3', 'province 4'].includes(card.location) && card.controller === player && card.isDynasty) {
             if(card.facedown && this.currentPhase === 'dynasty') {
                 card.facedown = false;
                 this.addMessage('{0} reveals {1}', player, card);
             }
-        }        
+        }*/        
     }
    
     /*

--- a/server/game/gamesteps/dynastyphase.js
+++ b/server/game/gamesteps/dynastyphase.js
@@ -33,9 +33,7 @@ class DynastyPhase extends Phase {
 
     flipDynastyCards () {
         _.each(this.game.getPlayersInFirstPlayerOrder(), player => {
-            if(player.optionSettings['flipDynasty']) {
-                player.flipDynastyCards();
-            }
+            this.game.queueSimpleStep(() => player.flipDynastyCards());
         });
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -251,12 +251,12 @@ class Player extends Spectator {
         _.each(['province 1', 'province 2', 'province 3', 'province 4'], province => {
             let card = this.getDynastyCardInProvince(province);
             if(card && card.facedown) {
-                card.facedown = false;
+                this.game.raiseEvent('onDynastyCardTurnedFaceup', { player: this, card: card }, () => card.facedown = false);
                 revealedCards.push(card);
             }
         });
         if(revealedCards.length > 0) {
-            this.game.addMessage('{0} reveals {1}', this, revealedCards);
+            this.game.queueSimpleStep(() => this.game.addMessage('{0} reveals {1}', this, revealedCards));
         }
     }
 

--- a/server/game/provincecard.js
+++ b/server/game/provincecard.js
@@ -18,11 +18,12 @@ class ProvinceCard extends BaseCard {
 
     getDynastyOrStrongholdCardModifier() {
         let province = this.controller.getSourceList(this.location);
-        let card = province.find(card => card !== this);
-        if(card) {
-            return card.getProvinceStrengthBonus();
-        }
-        return 0;
+        return province.reduce((bonus, card) => {
+            if(card !== this) {
+                return bonus + card.getProvinceStrengthBonus();
+            }
+            return bonus; 
+        }, 0);
     }
 
     getElement() {

--- a/test/server/cards/cancreatecards.spec.js
+++ b/test/server/cards/cancreatecards.spec.js
@@ -59,7 +59,8 @@ const eventNames = [
     'onSendCharactersHome',
     'onCardPlayed',
     'onDeckShuffled',
-    'onDuelResolution'
+    'onDuelResolution',
+    'onDynastyCardTurnedFaceup'
 ];
 
 describe('All Cards:', function() {


### PR DESCRIPTION
I've removed the ability to manually flip your own dynasty cards in the process of implementing this card.  I think that now there are cards which key off this action, and the rules of the game are very strict on the procedure involved in turning cards faceup (in player order, one at a time), it's better to automate it.

The UI is still not great for this (holdings stack on top of each other, so it's not clear how many copies of Mountaintop Statuary are on the stronghold province), so this is still dependent on #1191`being resolved