### PR TITLE
Spelled Mediator, not Mediatior

### DIFF
--- a/server/game/cards/02.4-TCT/UtakuMediatior.js
+++ b/server/game/cards/02.4-TCT/UtakuMediatior.js
@@ -1,6 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
-class UtakuMediatior extends DrawCard {
+class UtakuMediator extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: this,
@@ -13,6 +13,6 @@ class UtakuMediatior extends DrawCard {
     }
 }
 
-UtakuMediatior.id = 'utaku-mediatior';
+UtakuMediator.id = 'utaku-mediator';
 
-module.exports = UtakuMediatior;
+module.exports = UtakuMediator;


### PR DESCRIPTION
Closes #1278

All references to this card were spelled Utaku Mediatior, not Mediator, and since I tested it using a different card (this card data wasn't up until late Thursday) never caught that the spelling was off. Would recommend we try and get this pull in ASAP, since the card is completely borked as of right now.