### PR TITLE
Change reactions to only greyscale own cards

### DIFF
--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -73,6 +73,7 @@ class SelectCardPrompt extends UiPrompt {
         return {
             buttons: [{ text: 'Done', arg: 'done' }],
             pretarget: false,
+            selectMyCard: false,
             onSelect: () => true,
             onMenuCommand: () => true,
             onCancel: () => true
@@ -105,7 +106,8 @@ class SelectCardPrompt extends UiPrompt {
 
     activePrompt() {
         return {
-            selectCard: true,
+            selectCard: !this.properties.selectMyCard,
+            selectMyCard: this.properties.selectMyCard,
             selectOrder: this.properties.ordered,
             menuTitle: this.properties.activePromptTitle || this.selector.defaultActivePromptTitle(),
             buttons: this.properties.buttons,

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -100,6 +100,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
             activePromptTitle: TriggeredAbilityWindowTitles.getTitle(this.abilityType, this.events),
             buttons: buttons,
             controls: this.getAdditionalPromptControls(),
+            selectMyCard: true,
             waitingPromptTitle: 'Waiting for opponent',
             cardCondition: card => cards.includes(card),
             onMenuCommand: (player, arg) => {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -80,7 +80,7 @@ class Player extends Spectator {
 
         this.createAdditionalPile('out of game', { title: 'Out of Game', area: 'player row' });
 
-        this.promptState = new PlayerPromptState();
+        this.promptState = new PlayerPromptState(this);
     }
 
     /**

--- a/server/game/playerpromptstate.js
+++ b/server/game/playerpromptstate.js
@@ -1,8 +1,10 @@
 const _ = require('underscore');
 
 class PlayerPromptState {
-    constructor() {
+    constructor(player) {
+        this.player = player;
         this.selectCard = false;
+        this.selectMyCard = false;
         this.selectOrder = false;
         this.menuTitle = '';
         this.promptTitle = '';
@@ -31,6 +33,7 @@ class PlayerPromptState {
 
     setPrompt(prompt) {
         this.selectCard = prompt.selectCard || false;
+        this.selectMyCard = prompt.selectMyCard || false;
         this.selectOrder = prompt.selectOrder || false;
         this.menuTitle = prompt.menuTitle || '';
         this.promptTitle = prompt.promptTitle;
@@ -61,7 +64,7 @@ class PlayerPromptState {
             // which we do differently from normal card selection.
             selected: card.selected || (index !== -1),
             selectable: selectable,
-            unselectable: this.selectCard && !selectable
+            unselectable: (this.selectCard && !selectable) || (this.selectMyCard && !selectable && card.controller === this.player)
         };
 
         if(index !== -1 && this.selectOrder) {


### PR DESCRIPTION
I've had complaints that it's difficult to e.g. see which cards are attacking when deciding whether or not to use Rally to the cause.  This change means that only cards you control (and aren't usable) are greyed out