### PR TITLE
Crisis Breaker

### DIFF
--- a/server/game/cards/02.5-FHNS/CrisisBreaker.js
+++ b/server/game/cards/02.5-FHNS/CrisisBreaker.js
@@ -28,7 +28,7 @@ class CrisisBreaker extends DrawCard {
             target: {
                 activePromptTitle: 'Choose a character',
                 cardType: 'character',
-                cardCondition: card => card.location === 'play area' && card.hasTrait('berserker') && (!card.isParticipating() || card.bowed)
+                cardCondition: card => card.location === 'play area' && card.hasTrait('berserker') && (card.allowGameAction('moveToConflict') || card.allowGameAction('ready'))
             },
             handler: context => {
                 this.game.addMessage('{0} uses {1} to ready {2} and move it into the conflict', this.controller, this, context.target);

--- a/server/game/cards/02.5-FHNS/CrisisBreaker.js
+++ b/server/game/cards/02.5-FHNS/CrisisBreaker.js
@@ -7,7 +7,7 @@ class CrisisBreaker extends DrawCard {
             condition: () => {
                 const currentConflict = this.game.currentConflict;
 
-                if (!currentConflict || currentConflict.conflictType !== 'military') {
+                if(!currentConflict || currentConflict.conflictType !== 'military') {
                     return false;
                 }
 

--- a/server/game/cards/02.5-FHNS/CrisisBreaker.js
+++ b/server/game/cards/02.5-FHNS/CrisisBreaker.js
@@ -1,10 +1,44 @@
 const DrawCard = require('../../drawcard.js');
 
 class CrisisBreaker extends DrawCard {
-    setupCardAbilities(ability) { // eslint-disable-line no-unused-vars
+    setupCardAbilities() {
+        this.action({
+            title: 'Ready and bring into play',
+            condition: () => {
+                const currentConflict = this.game.currentConflict;
+
+                if (!currentConflict || currentConflict.conflictType !== 'military') {
+                    return false;
+                }
+
+                const originalSkillFunction = currentConflict.skillFunction;
+
+                currentConflict.skillFunction = (card) => card.getSkill('military');
+                currentConflict.calculateSkill();
+
+                const conditionFulfilled = currentConflict.attackingPlayer === this.controller ?
+                    currentConflict.attackerSkill < currentConflict.defenderSkill :
+                    currentConflict.defenderSkill < currentConflict.attackerSkill;
+
+                currentConflict.skillFunction = originalSkillFunction;
+                currentConflict.calculateSkill();
+
+                return conditionFulfilled;
+            },
+            target: {
+                activePromptTitle: 'Choose a character',
+                cardType: 'character',
+                cardCondition: card => card.location === 'play area' && card.hasTrait('berserker') && (!card.isParticipating() || card.bowed)
+            },
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to ready {2} and move it into the conflict', this.controller, this, context.target);
+                this.controller.readyCard(context.target, this);
+                this.game.currentConflict.moveToConflict(context.target);
+            }
+        });
     }
 }
 
-CrisisBreaker.id = 'crisis-breaker'; // This is a guess at what the id might be - please check it!!!
+CrisisBreaker.id = 'crisis-breaker';
 
 module.exports = CrisisBreaker;


### PR DESCRIPTION
Closes #1245

I had to make a few changes to conflict.js, mostly due to Crisis Breaker fighting at Massing At Twilight, although I'm guessing this won't be the last time something like this is relevant. Noted changes are making a copy of calculateSkillFor where the skillFunction added in #1300 will never change and splitting attackerSkillModifier into attackerMilitarySkillModifier and attackerPoliticalSkillModifier (did same for defender). 

Added two functions, compareMilitary() and comparePolitical(). They return the difference between attacker and defender skill of the given conflict type ( < 0 => attacker is lower, = means equal, > 0 means attacker higher).