### PR TITLE
Implementing Mono No Aware

### DIFF
--- a/server/game/cards/02.6-MotE/MonoNoAware.js
+++ b/server/game/cards/02.6-MotE/MonoNoAware.js
@@ -1,7 +1,27 @@
+const _ = require('underscore');
 const DrawCard = require('../../drawcard.js');
 
 class MonoNoAware extends DrawCard {
     setupCardAbilities(ability) { // eslint-disable-line no-unused-vars
+		this.action({
+            title: 'Remove 1 fate from each character. Draw 1 card.',
+            condition: () => this.controller.cardsInPlay.any(card => card.fate > 0) || (this.controller.opponent &&
+                             this.controller.opponent.cardsInPlay.any(card => card.fate > 0)),
+            handler: () => {
+                this.game.addMessage('{0} plays {1}', this.controller, this);
+                let cards = this.game.findAnyCardsInPlay(card => {
+					return (card.type === 'character' &&
+							card.allowGameAction('removeFate') &&
+							card.fate > 0);
+				});
+				this.game.raiseMultipleEvents(_.map(cards, card => ({
+					name: 'onCardRemoveFate',
+					params: { card: card, fate: 1 }
+				})));
+				this.controller.drawCardsToHand(1);
+				},
+				max: ability.limit.perRound(1)	
+        });
     }
 }
 

--- a/server/game/cards/02.6-MotE/MonoNoAware.js
+++ b/server/game/cards/02.6-MotE/MonoNoAware.js
@@ -3,24 +3,24 @@ const DrawCard = require('../../drawcard.js');
 
 class MonoNoAware extends DrawCard {
     setupCardAbilities(ability) { // eslint-disable-line no-unused-vars
-		this.action({
+        this.action({
             title: 'Remove 1 fate from each character. Draw 1 card.',
             condition: () => this.controller.cardsInPlay.any(card => card.fate > 0) || (this.controller.opponent &&
                              this.controller.opponent.cardsInPlay.any(card => card.fate > 0)),
             handler: () => {
                 this.game.addMessage('{0} plays {1}', this.controller, this);
                 let cards = this.game.findAnyCardsInPlay(card => {
-					return (card.type === 'character' &&
-							card.allowGameAction('removeFate') &&
-							card.fate > 0);
-				});
-				this.game.raiseMultipleEvents(_.map(cards, card => ({
-					name: 'onCardRemoveFate',
-					params: { card: card, fate: 1 }
-				})));
-				this.controller.drawCardsToHand(1);
-				},
-				max: ability.limit.perRound(1)	
+                    return (card.type === 'character' &&
+                            card.allowGameAction('removeFate') &&
+                            card.fate > 0);
+                });
+                this.game.raiseMultipleEvents(_.map(cards, card => ({
+                    name: 'onCardRemoveFate',
+                    params: { card: card, fate: 1 }
+                })));
+                this.controller.drawCardsToHand(1);
+            },
+            max: ability.limit.perRound(1)    
         });
     }
 }


### PR DESCRIPTION
Mono no Aware
Neutral Event.

Cost: 3.

Action: Remove 1 fate from each character. Draw 1 card. (Max 1 per round.)

Conflict Deck – Influence Cost: 0