### PR TITLE
Use flex layout in province deck popup

### DIFF
--- a/less/gameboard/sidebar/province-deck.less
+++ b/less/gameboard/sidebar/province-deck.less
@@ -19,12 +19,15 @@
     .popup {
         position: absolute;
         min-height: 92px;
-        min-width: 168px;
+        min-width: 180px;
         left: 90px;
         top: -75px;
 
         .inner {
-            columns: 2;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-evenly;
+            align-items: flex-start;
             min-height: 128px;
 
             .card-wrapper {
@@ -35,6 +38,17 @@
         &.hidden {
             display: none;
         }
+    }
 
+    &.large {
+        .popup {
+            min-width: 240px
+        }
+    }
+
+    &.x-large {
+        .popup {
+            min-width: 320px
+        }
     }
 }


### PR DESCRIPTION
Removed the column CSS layout from province deck popup due to a Chrome bug not displaying images in further columns properly and replaced it with flexbox instead.

Resolves #1467 