### PR TITLE
When a card is unselectable, gray out just the image, not the outline

### DIFF
--- a/less/cards.less
+++ b/less/cards.less
@@ -99,9 +99,13 @@
     box-shadow: 0 0 10px 1px fadeout(lighten(@brand-primary, 60%), 10%);
   }
 
-  &.unselectable {
-    filter: grayscale(100%) brightness(60%);
-  }
+    &.unselectable {
+        filter: brightness(60%);
+
+        .card-image {
+            filter: grayscale(100%);
+        }
+    }
 
   &.in-danger {
     box-shadow: 0 0 1px 2px red;
@@ -136,7 +140,7 @@
   &.small {
     &.vertical {
       height: @card-sm-height;
-      width: @card-sm-width;      
+      width: @card-sm-width;
     }
 
     &.horizontal {
@@ -158,7 +162,7 @@
   &.large {
     &.vertical {
       height: @card-lg-height;
-      width: @card-lg-width;      
+      width: @card-lg-width;
     }
 
     &.horizontal {
@@ -175,7 +179,7 @@
   &.x-large {
     &.vertical {
       height: @card-xl-height;
-      width: @card-xl-width;      
+      width: @card-xl-width;
     }
 
     &.horizontal {
@@ -195,7 +199,7 @@
     transform: rotate(90deg);
 
   }
-  
+
   &.broken {
       transform: rotate(180deg);
   }
@@ -266,17 +270,17 @@
   margin-top: -(@card-height);
 
   &.small {
-    margin-top: -(@card-sm-height); 
+    margin-top: -(@card-sm-height);
 
   }
 
   &.large {
-    margin-top: -(@card-lg-height);  
+    margin-top: -(@card-lg-height);
 
   }
 
   &.x-large {
-    margin-top: -(@card-xl-height); 
+    margin-top: -(@card-xl-height);
 
   }
 
@@ -367,7 +371,7 @@
   text-align: center;
   font-size: 14px;
   color: white;
-  text-shadow: 1px 1px 2px #000;  
+  text-shadow: 1px 1px 2px #000;
 }
 
 .fatecounter {


### PR DESCRIPTION
This will allow us to make all cards unaffected by effect XYZ unselectable, while still allowing the user to recognize which characters are participating in a conflict.