### PR TITLE
Rework the way persistent effects generate their target lists

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -74,14 +74,11 @@ class Effect {
 
         if(!_.isFunction(this.match)) {
             this.addTargets([this.match]);
-        }
-
-        if(this.targetType === 'player') {
+        } else if(this.targetType === 'player') {
             this.addTargets(_.values(this.game.getPlayers()))
+        } else {
+            this.addTargets(this.game.findAnyCardsInPlay(this.match));
         }
-
-        this.addTargets(this.game.findAnyCardsInPlay(() => true));
-        
     }
 
     addTargets(targets) {
@@ -165,7 +162,7 @@ class Effect {
         return this.targets.includes(card);
     }
 
-    setActive(newActive, newTargets) {
+    setActive(newActive) {
         let oldActive = this.active;
 
         this.active = newActive;

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -67,6 +67,23 @@ class Effect {
         return ['any', this.source.location].includes(this.location);
     }
 
+    getTargets() {
+        if(!this.active || !this.condition()) {
+            return;
+        }
+
+        if(!_.isFunction(this.match)) {
+            this.addTargets([this.match]);
+        }
+
+        if(this.targetType === 'player') {
+            this.addTargets(_.values(this.game.getPlayers()))
+        }
+
+        this.addTargets(this.game.findAnyCardsInPlay(() => true));
+        
+    }
+
     addTargets(targets) {
         if(!this.active || !this.condition()) {
             return;
@@ -158,7 +175,7 @@ class Effect {
         }
 
         if(!oldActive && newActive) {
-            this.addTargets(newTargets);
+            this.getTargets();
         }
     }
 
@@ -167,7 +184,7 @@ class Effect {
         this.targets = [];
     }
 
-    reapply(newTargets) {
+    reapply() {
         if(!this.active) {
             return;
         }
@@ -185,7 +202,7 @@ class Effect {
                 _.each(invalidTargets, target => {
                     this.removeTarget(target);
                 });
-                this.addTargets(newTargets);
+                this.getTargets();
             }
         }
 

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -75,7 +75,7 @@ class Effect {
         if(!_.isFunction(this.match)) {
             this.addTargets([this.match]);
         } else if(this.targetType === 'player') {
-            this.addTargets(_.values(this.game.getPlayers()))
+            this.addTargets(_.values(this.game.getPlayers()));
         } else {
             this.addTargets(this.game.getTargetsForEffect(this.match));
         }

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -77,7 +77,7 @@ class Effect {
         } else if(this.targetType === 'player') {
             this.addTargets(_.values(this.game.getPlayers()))
         } else {
-            this.addTargets(this.game.findAnyCardsInPlay(this.match));
+            this.addTargets(this.game.getTargetsforEffect(this.match));
         }
     }
 

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -77,7 +77,7 @@ class Effect {
         } else if(this.targetType === 'player') {
             this.addTargets(_.values(this.game.getPlayers()))
         } else {
-            this.addTargets(this.game.getTargetsforEffect(this.match));
+            this.addTargets(this.game.getTargetsForEffect(this.match));
         }
     }
 

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -25,16 +25,16 @@ class EffectEngine {
             this.registerCustomDurationEvents(effect);
         }
     }
-
+    /*
     getTargets() {
         var validTargets = this.game.allCards.filter(card => ['province 1', 'province 2', 'province 3', 'province 4', 'stronghold province', 'play area', 'hand'].includes(card.location));
         return validTargets.concat(_.values(this.game.getPlayers()));
     }
-
+    */
     reapplyStateDependentEffects() {
         _.each(this.effects, effect => {
             if(effect.isStateDependent) {
-                effect.reapply(this.getTargets());
+                effect.reapply();
             }
         });
     }
@@ -56,7 +56,7 @@ class EffectEngine {
                 // effect for existing targets and then recalculate effects for
                 // the new controller from scratch.
                 effect.cancel();
-                effect.addTargets(this.getTargets());
+                effect.getTargets();
             } else if(effect.duration === 'persistent' && effect.hasTarget(card) && !effect.isValidTarget(card)) {
                 // Evict the card from any effects applied on it that are no
                 // longer valid under the new controller.
@@ -106,10 +106,9 @@ class EffectEngine {
 
     onCardBlankToggled(event) {
         let {card, isBlank} = event;
-        let targets = this.getTargets();
         let matchingEffects = _.filter(this.effects, effect => effect.duration === 'persistent' && effect.source === card);
         _.each(matchingEffects, effect => {
-            effect.setActive(!isBlank, targets);
+            effect.setActive(!isBlank);
         });
     }
 

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -25,12 +25,7 @@ class EffectEngine {
             this.registerCustomDurationEvents(effect);
         }
     }
-    /*
-    getTargets() {
-        var validTargets = this.game.allCards.filter(card => ['province 1', 'province 2', 'province 3', 'province 4', 'stronghold province', 'play area', 'hand'].includes(card.location));
-        return validTargets.concat(_.values(this.game.getPlayers()));
-    }
-    */
+
     reapplyStateDependentEffects() {
         _.each(this.effects, effect => {
             if(effect.isStateDependent) {

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -19,7 +19,7 @@ class EffectEngine {
 
         this.effects.push(effect);
         this.effects = _.sortBy(this.effects, effect => effect.order);
-        effect.addTargets(this.getTargets());
+        effect.getTargets();
         this.registerRecalculateEvents(effect.recalculateWhen);
         if(effect.duration === 'custom') {
             this.registerCustomDurationEvents(effect);
@@ -89,7 +89,7 @@ class EffectEngine {
 
     addTargetForPersistentEffects(card, targetLocation) {
         _.each(this.effects, effect => {
-            if(effect.duration === 'persistent' && effect.targetLocation === targetLocation) {
+            if(effect.duration === 'persistent' && effect.targetLocation === targetLocation && (_.isFunction(effect.match) || effect.match === card)) {
                 effect.addTargets([card]);
             }
         });

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -245,6 +245,10 @@ class Game extends EventEmitter {
         return foundCards;
     }
 
+    getTargetsForEffect(match) {
+        return this.findAnyCardsInPlay(match).concat(this.provinceCards);
+    }
+
     /*
      * Adds a persistent/lasting/delayed effect to the effect engine
      * @param {BaseCard} source - card generating the effect
@@ -1066,6 +1070,7 @@ class Game extends EventEmitter {
         this.allCards = _(_.reduce(this.getPlayers(), (cards, player) => {
             return cards.concat(player.preparedDeck.allCards);
         }, []));
+        this.provinceCards = this.allCards.find(card => card.isProvince);
 
         if(playerWithNoStronghold) {
             this.addMessage('{0} does not have a stronghold in their decklist', playerWithNoStronghold);

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -12,7 +12,7 @@ function createTarget(properties = {}) {
 
 describe('Effect', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['']);
+        this.gameSpy = jasmine.createSpyObj('game', ['findAnyCardsInPlay']);
         this.sourceSpy = jasmine.createSpyObj('source', ['getType', 'isBlank']);
         this.properties = {
             match: jasmine.createSpy('match'),
@@ -396,6 +396,7 @@ describe('Effect', function() {
         beforeEach(function() {
             this.target = createTarget({ target: 1, location: 'play area' });
             this.newTarget = createTarget({ target: 2, location: 'play area' });
+            this.gameSpy.findAnyCardsInPlay.and.returnValue([this.newTarget]);
         });
 
         describe('when the effect is active', function() {
@@ -406,7 +407,7 @@ describe('Effect', function() {
 
             describe('and is set to inactive', function() {
                 beforeEach(function() {
-                    this.effect.setActive(false, [this.newTarget]);
+                    this.effect.setActive(false);
                 });
 
                 it('should unapply the effect from existing targets', function() {
@@ -428,7 +429,7 @@ describe('Effect', function() {
 
             describe('and is set to active', function() {
                 beforeEach(function() {
-                    this.effect.setActive(true, [this.newTarget]);
+                    this.effect.setActive(true);
                 });
 
                 it('should not unapply the effect from existing targets', function() {
@@ -457,7 +458,7 @@ describe('Effect', function() {
 
             describe('and is set to inactive', function() {
                 beforeEach(function() {
-                    this.effect.setActive(false, [this.newTarget]);
+                    this.effect.setActive(false);
                 });
 
                 it('should not unapply the effect', function() {
@@ -475,7 +476,7 @@ describe('Effect', function() {
 
             describe('and is set to active', function() {
                 beforeEach(function() {
-                    this.effect.setActive(true, [this.newTarget]);
+                    this.effect.setActive(true);
                 });
 
                 it('should not unapply the effect', function() {
@@ -655,7 +656,8 @@ describe('Effect', function() {
                     this.effect.active = true;
                     this.effect.condition.and.returnValue(true);
                     this.properties.match.and.callFake(card => card !== this.target);
-                    this.effect.reapply(this.newTargets);
+                    this.gameSpy.findAnyCardsInPlay.and.returnValue([this.newTarget, this.target, this.matchingTarget]);
+                    this.effect.reapply();
                 });
 
                 it('should apply the effect to new targets', function() {

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -12,7 +12,7 @@ function createTarget(properties = {}) {
 
 describe('Effect', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['findAnyCardsInPlay']);
+        this.gameSpy = jasmine.createSpyObj('game', ['getTargetsForEffect']);
         this.sourceSpy = jasmine.createSpyObj('source', ['getType', 'isBlank']);
         this.properties = {
             match: jasmine.createSpy('match'),
@@ -396,7 +396,7 @@ describe('Effect', function() {
         beforeEach(function() {
             this.target = createTarget({ target: 1, location: 'play area' });
             this.newTarget = createTarget({ target: 2, location: 'play area' });
-            this.gameSpy.findAnyCardsInPlay.and.returnValue([this.newTarget]);
+            this.gameSpy.getTargetsForEffect.and.returnValue([this.newTarget]);
         });
 
         describe('when the effect is active', function() {
@@ -656,7 +656,7 @@ describe('Effect', function() {
                     this.effect.active = true;
                     this.effect.condition.and.returnValue(true);
                     this.properties.match.and.callFake(card => card !== this.target);
-                    this.gameSpy.findAnyCardsInPlay.and.returnValue([this.newTarget, this.target, this.matchingTarget]);
+                    this.gameSpy.getTargetsForEffect.and.returnValue([this.newTarget, this.target, this.matchingTarget]);
                     this.effect.reapply();
                 });
 

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -12,9 +12,10 @@ describe('EffectEngine', function () {
         this.gameSpy.getPlayers.and.returnValue([]);
         this.gameSpy.allCards = _([this.handCard, this.playAreaCard, this.discardedCard]);
 
-        this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'isInActiveLocation', 'reapply', 'removeTarget', 'cancel', 'setActive']);
+        this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'getTargets', 'isInActiveLocation', 'reapply', 'removeTarget', 'cancel', 'setActive']);
         this.effectSpy.isInActiveLocation.and.returnValue(true);
         this.effectSpy.targetLocation = 'play area';
+        this.effectSpy.match = () => true;
 
         this.engine = new EffectEngine(this.gameSpy);
     });
@@ -29,7 +30,7 @@ describe('EffectEngine', function () {
         });
 
         it('should add existing valid targets to the effect', function() {
-            expect(this.effectSpy.addTargets).toHaveBeenCalledWith([this.handCard, this.playAreaCard]);
+            expect(this.effectSpy.getTargets).toHaveBeenCalled();
         });
 
         describe('when the effect has custom duration', function() {
@@ -49,7 +50,7 @@ describe('EffectEngine', function () {
         });
     });
 
-    describe('getTargets()', function() {
+    xdescribe('getTargets()', function() {
         beforeEach(function() {
             this.player = {};
             this.gameSpy.getPlayers.and.returnValue([this.player]);
@@ -72,7 +73,7 @@ describe('EffectEngine', function () {
             });
 
             it('should reapply valid targets', function() {
-                expect(this.effectSpy.reapply).toHaveBeenCalledWith([this.handCard, this.playAreaCard]);
+                expect(this.effectSpy.reapply).toHaveBeenCalled();
             });
         });
 
@@ -271,7 +272,7 @@ describe('EffectEngine', function () {
                 });
 
                 it('should set the active value for the effect along with cards to target', function() {
-                    expect(this.effectSpy.setActive).toHaveBeenCalledWith(true, [this.handCard, this.playAreaCard]);
+                    expect(this.effectSpy.setActive).toHaveBeenCalledWith(true);
                 });
             });
 
@@ -470,7 +471,7 @@ describe('EffectEngine', function () {
             this.effectSpy.until = {
                 foo: jasmine.createSpy('listener')
             };
-            this.effectSpy2 = jasmine.createSpyObj('effect', ['addTargets', 'isInActiveLocation', 'reapply', 'removeTarget', 'cancel', 'setActive']);
+            this.effectSpy2 = jasmine.createSpyObj('effect', ['addTargets', 'getTargets', 'isInActiveLocation', 'reapply', 'removeTarget', 'cancel', 'setActive']);
             this.effectSpy2.isInActiveLocation.and.returnValue(true);
             this.effectSpy2.targetLocation = 'play area';
             this.effectSpy2.duration = 'custom';


### PR DESCRIPTION
Tests I've been writing with the new test suite tools have brought to light some problems with the way persistent effects work:  
- The effect engine seems to be written around the assumption that persistent effects will only affect cards in play or in a players hand.  L5R has a lot of effects which affect targets in other places (provinces/deck/discard pile)
- Previous code changes have expanded the way targets are selected, but reapplication of state-dependent effects is one of the areas where server load can be strained, so I'm reluctant to put further strain in this area.

In fact, a lot of persistent/lasting effects only have a single target, and those that don't almost always only affect targets in the play area.  In light of this, I've refactored the way persistent/lasting effect targeting works so that effects which can only have a single target don't try and create a full list of targets from all the cards in the game.  This means that effects which do affect multiple targets can now be restricted to only looking at cards in the play area and provinces, which should reduce the strain caused by reapplyStateDependentEffects()