### PR TITLE
Make ability limits per player

### DIFF
--- a/server/game/abilitylimit.js
+++ b/server/game/abilitylimit.js
@@ -1,7 +1,7 @@
 class FixedAbilityLimit {
     constructor(max) {
         this.max = max;
-        this.useCount = 0;
+        this.useCount = {};
     }
 
     isRepeatable() {
@@ -12,16 +12,20 @@ class FixedAbilityLimit {
         this.max = this.max + amount;
     }
 
-    isAtMax() {
-        return this.useCount >= this.max;
+    isAtMax(player) {
+        return this.useCount[player.name] && this.useCount[player.name] >= this.max;
     }
 
-    increment() {
-        this.useCount += 1;
+    increment(player) {
+        if(this.useCount[player.name]) {
+            this.useCount[player.name] += 1;
+        } else {
+            this.useCount[player.name] = 1;
+        }
     }
 
     reset() {
-        this.useCount = 0;
+        this.useCount = {};
     }
 
     registerEvents() {

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -167,7 +167,7 @@ const Costs = {
     useLimit: function() {
         return {
             canPay: function(context) {
-                return !context.ability.limit.isAtMax();
+                return !context.ability.limit.isAtMax(context.player);
             },
             canIgnoreForTargeting: true
         };

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -112,7 +112,7 @@ class AbilityResolver extends BaseStepWithPipeline {
         // Increment limits (limits aren't used up on cards in hand)
         if(this.context.ability.limit && this.context.source.location !== 'hand' &&
            (!this.context.cardStateWhenInitiated || this.context.cardStateWhenInitiated.location === this.context.source.location)) {
-            this.context.ability.limit.increment();
+            this.context.ability.limit.increment(this.context.player);
         }
         if(this.context.ability.max) {
             this.context.player.incrementAbilityMax(this.context.ability.maxIdentifier);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -830,7 +830,7 @@ class Player extends Spectator {
             return false;
         }
 
-        return limit.isAtMax();
+        return limit.isAtMax(this);
     }
 
     /**

--- a/test/server/abilitylimit.spec.js
+++ b/test/server/abilitylimit.spec.js
@@ -5,36 +5,37 @@ const AbilityLimit = require('../../server/game/abilitylimit.js');
 describe('AbilityLimit', function () {
     beforeEach(function () {
         this.eventEmitterSpy = jasmine.createSpyObj('event emitter', ['on', 'removeListener']);
+        this.player = { name: 'player1' };
 
         this.limit = AbilityLimit.repeatable(2, 'onEventForReset');
     });
 
     describe('increment()', function() {
         it('should increase the use count', function() {
-            this.limit.increment();
-            expect(this.limit.useCount).toBe(1);
+            this.limit.increment(this.player);
+            expect(this.limit.useCount.player1).toBe(1);
         });
     });
 
     describe('isAtMax', function() {
         describe('when below the max', function() {
             beforeEach(function() {
-                this.limit.increment();
+                this.limit.increment(this.player);
             });
 
             it('should return false', function() {
-                expect(this.limit.isAtMax()).toBe(false);
+                expect(this.limit.isAtMax(this.player)).toBe(false);
             });
         });
 
         describe('when at the max', function() {
             beforeEach(function() {
-                this.limit.increment();
-                this.limit.increment();
+                this.limit.increment(this.player);
+                this.limit.increment(this.player);
             });
 
             it('should return false', function() {
-                expect(this.limit.isAtMax()).toBe(true);
+                expect(this.limit.isAtMax(this.player)).toBe(true);
             });
         });
     });
@@ -58,7 +59,7 @@ describe('AbilityLimit', function () {
             this.eventEmitter = new EventEmitter();
 
             this.limit.registerEvents(this.eventEmitter);
-            this.limit.increment();
+            this.limit.increment(this.player);
         });
 
         afterEach(function() {
@@ -67,7 +68,7 @@ describe('AbilityLimit', function () {
 
         it('should set the use count to 0', function() {
             this.eventEmitter.emit('onEventForReset');
-            expect(this.limit.useCount).toBe(0);
+            expect(this.limit.useCount.player1).toBeUndefined();
         });
     });
 });

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -8,6 +8,7 @@ describe('CardForcedReaction', function () {
         this.cardSpy.location = 'play area';
         this.cardSpy.canTriggerAbilities.and.returnValue(true);
         this.cardSpy.abilities = { reactions: [] };
+        this.cardSpy.controller = { name: 'player1' };
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 
         this.properties = {
@@ -72,7 +73,7 @@ describe('CardForcedReaction', function () {
         });
 
         it('should call the when handler with the appropriate arguments', function() {
-            this.meetsRequirements();
+            this.meetsRequirements(this.context);
             expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event, 1, 2, 3);
         });
 
@@ -82,7 +83,7 @@ describe('CardForcedReaction', function () {
             });
 
             it('should return false', function() {
-                expect(this.meetsRequirements()).toBe(false);
+                expect(this.meetsRequirements(this.context)).toBe(false);
             });
         });
 
@@ -92,7 +93,7 @@ describe('CardForcedReaction', function () {
             });
 
             it('should return false', function() {
-                expect(this.meetsRequirements()).toBe(false);
+                expect(this.meetsRequirements(this.context)).toBe(false);
             });
         });
 
@@ -102,7 +103,7 @@ describe('CardForcedReaction', function () {
             });
 
             it('should return false', function() {
-                expect(this.meetsRequirements()).toBe(false);
+                expect(this.meetsRequirements(this.context)).toBe(false);
             });
         });
 
@@ -113,7 +114,7 @@ describe('CardForcedReaction', function () {
             });
 
             it('should return false', function() {
-                expect(this.meetsRequirements()).toBe(false);
+                expect(this.meetsRequirements(this.context)).toBe(false);
             });
         });
 
@@ -128,7 +129,7 @@ describe('CardForcedReaction', function () {
                 });
 
                 it('should return false', function() {
-                    expect(this.meetsRequirements()).toBe(false);
+                    expect(this.meetsRequirements(this.context)).toBe(false);
                 });
             });
 
@@ -138,7 +139,7 @@ describe('CardForcedReaction', function () {
                 });
 
                 it('should return true', function() {
-                    expect(this.meetsRequirements()).toBe(true);
+                    expect(this.meetsRequirements(this.context)).toBe(true);
                 });
             });
         });

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -8,6 +8,7 @@ describe('CardReaction', function () {
         this.cardSpy.location = 'play area';
         this.cardSpy.canTriggerAbilities.and.returnValue(true);
         this.cardSpy.abilities = { reactions: [] };
+        this.cardSpy.controller = { name: 'player1' };
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 
         this.properties = {
@@ -82,7 +83,7 @@ describe('CardReaction', function () {
         });
 
         it('should call the when handler with the appropriate arguments', function() {
-            this.meetsRequirements();
+            this.meetsRequirements(this.context);
             expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event, 1, 2, 3);
         });
 
@@ -92,7 +93,7 @@ describe('CardReaction', function () {
             });
 
             it('should return false', function() {
-                expect(this.meetsRequirements()).toBe(false);
+                expect(this.meetsRequirements(this.context)).toBe(false);
             });
         });
 
@@ -102,7 +103,7 @@ describe('CardReaction', function () {
             });
 
             it('should return false', function() {
-                expect(this.meetsRequirements()).toBe(false);
+                expect(this.meetsRequirements(this.context)).toBe(false);
             });
         });
 
@@ -112,7 +113,7 @@ describe('CardReaction', function () {
             });
 
             it('should return false', function() {
-                expect(this.meetsRequirements()).toBe(false);
+                expect(this.meetsRequirements(this.context)).toBe(false);
             });
         });
 
@@ -123,7 +124,7 @@ describe('CardReaction', function () {
             });
 
             it('should return false', function() {
-                expect(this.meetsRequirements()).toBe(false);
+                expect(this.meetsRequirements(this.context)).toBe(false);
             });
         });
 
@@ -138,7 +139,7 @@ describe('CardReaction', function () {
                 });
 
                 it('should return false', function() {
-                    expect(this.meetsRequirements()).toBe(false);
+                    expect(this.meetsRequirements(this.context)).toBe(false);
                 });
             });
 
@@ -148,7 +149,7 @@ describe('CardReaction', function () {
                 });
 
                 it('should return true', function() {
-                    expect(this.meetsRequirements()).toBe(true);
+                    expect(this.meetsRequirements(this.context)).toBe(true);
                 });
             });
         });
@@ -165,7 +166,7 @@ describe('CardReaction', function () {
                 });
 
                 it('should return true', function() {
-                    expect(this.meetsRequirements()).toBe(true);
+                    expect(this.meetsRequirements(this.context)).toBe(true);
                 });
             });
 
@@ -175,7 +176,7 @@ describe('CardReaction', function () {
                 });
 
                 it('should return false', function() {
-                    expect(this.meetsRequirements()).toBe(false);
+                    expect(this.meetsRequirements(this.context)).toBe(false);
                 });
             });
         });


### PR DESCRIPTION
Ability limits are technically per player (i.e. each player can trigger an ability 1/round or whatever).  These changes mean that the game tracks which player has used an ability, and allow the other player to use that ability if a card changes control during the course of a turn