### PR TITLE
move breakProvince code to provincecard.js

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1661,30 +1661,6 @@ class Player extends Spectator {
         }
         this.game.raiseEvent('onBreakProvince', { conflict: this.game.currentConflict, province: province }, () => {
             province.breakProvince();
-            this.game.reapplyStateDependentEffects();
-            if(province.controller.opponent) {
-                this.game.addMessage('{0} has broken {1}!', province.controller.opponent, province);
-                if(province.location === 'stronghold province') {
-                    this.game.recordWinner(province.controller.opponent, 'conquest');
-                } else {
-                    let dynastyCard = province.controller.getDynastyCardInProvince(province.location);
-                    if(dynastyCard) {
-                        let promptTitle = 'Do you wish to discard ' + (dynastyCard.facedown ? 'the facedown card' : dynastyCard.name) + '?';
-                        this.game.promptWithHandlerMenu(province.controller.opponent, {
-                            activePromptTitle: promptTitle,
-                            source: 'Break ' + province.name,
-                            choices: ['Yes', 'No'],
-                            handlers: [
-                                () => {
-                                    this.game.addMessage('{0} chooses to discard {1}', province.controller.opponent, dynastyCard.facedown ? 'the facedown card' : dynastyCard);
-                                    province.controller.moveCard(dynastyCard, 'dynasty discard pile');
-                                },
-                                () => this.game.addMessage('{0} chooses not to discard {1}', province.controller.opponent, dynastyCard.facedown ? 'the facedown card' : dynastyCard)
-                            ]
-                        });
-                    }
-                }
-            }
             return { resolved: true, success: true };
         });
     }

--- a/server/game/provincecard.js
+++ b/server/game/provincecard.js
@@ -49,6 +49,30 @@ class ProvinceCard extends BaseCard {
 
     breakProvince() {
         this.isBroken = true;
+        this.game.reapplyStateDependentEffects();
+        if(this.controller.opponent) {
+            this.game.addMessage('{0} has broken {1}!', this.controller.opponent, this);
+            if(this.location === 'stronghold province') {
+                this.game.recordWinner(this.controller.opponent, 'conquest');
+            } else {
+                let dynastyCard = this.controller.getDynastyCardInProvince(this.location);
+                if(dynastyCard) {
+                    let promptTitle = 'Do you wish to discard ' + (dynastyCard.facedown ? 'the facedown card' : dynastyCard.name) + '?';
+                    this.game.promptWithHandlerMenu(this.controller.opponent, {
+                        activePromptTitle: promptTitle,
+                        source: 'Break ' + this.name,
+                        choices: ['Yes', 'No'],
+                        handlers: [
+                            () => {
+                                this.game.addMessage('{0} chooses to discard {1}', this.controller.opponent, dynastyCard.facedown ? 'the facedown card' : dynastyCard);
+                                this.controller.moveCard(dynastyCard, 'dynasty discard pile');
+                            },
+                            () => this.game.addMessage('{0} chooses not to discard {1}', this.controller.opponent, dynastyCard.facedown ? 'the facedown card' : dynastyCard)
+                        ]
+                    });
+                }
+            }
+        }
     }
 
     canTriggerAbilities() {


### PR DESCRIPTION
I'm trying to reorganise bits of the codebase to make it a bit more intuitive, and so this PR moves the breakProvince code from Player (which is a bit overloaded) to ProvinceCard