### PR TITLE
Remove result from Event

### DIFF
--- a/server/game/Events/Event.js
+++ b/server/game/Events/Event.js
@@ -8,8 +8,8 @@ class Event {
         this.handler = handler;
         this.window = null;
         this.thenEvents = [];
+        this.success = false;
         this.parentEvent = null;
-        this.result = { resolved: false, success: false};
         this.uuid = uuid.v1();
 
         _.extend(this, params);
@@ -21,7 +21,6 @@ class Event {
 
     cancel() {
         this.cancelled = true;
-        this.resolved = false;
         this.window.removeEvent(this);
     }
     
@@ -44,8 +43,9 @@ class Event {
     }
     
     executeHandler() {
+        this.success = true;
         if(this.handler) {
-            this.result = this.handler(...this.params) || { resolved: true, success: true};
+            this.handler(...this.params);
         }
     }
 

--- a/server/game/Events/Event.js
+++ b/server/game/Events/Event.js
@@ -8,7 +8,7 @@ class Event {
         this.handler = handler;
         this.window = null;
         this.thenEvents = [];
-        this.success = false;
+        this.isSuccessful = () => false;
         this.parentEvent = null;
         this.uuid = uuid.v1();
 
@@ -43,7 +43,7 @@ class Event {
     }
     
     executeHandler() {
-        this.success = true;
+        this.isSuccessful = () => true;
         if(this.handler) {
             this.handler(...this.params);
         }

--- a/server/game/Events/LeavesPlayEvent.js
+++ b/server/game/Events/LeavesPlayEvent.js
@@ -53,7 +53,6 @@ class LeavesPlayEvent extends Event {
 
     leavesPlay() {
         this.card.owner.moveCard(this.card, this.destination);
-        return { resolved: true, success: true };
     }
 }
 

--- a/server/game/Events/RemoveFateEvent.js
+++ b/server/game/Events/RemoveFateEvent.js
@@ -12,7 +12,6 @@ class RemoveFateEvent extends Event {
         if(this.recipient && this.recipient.modifyFate) {
             this.recipient.modifyFate(fate);
         }
-        return true;
     }
 }
 

--- a/server/game/cards/02.3-ItFC/BackAlleyHideaway.js
+++ b/server/game/cards/02.3-ItFC/BackAlleyHideaway.js
@@ -92,7 +92,6 @@ class BackAlleyHideaway extends DrawCard {
                     this.attachments.push(event.card);
                     event.card.parent = this;
                     event.card.abilities.playActions.push(new BackAlleyPlayCharacterAction(this));
-                    return { resolved: true, success: true };
                 });
             }
         });

--- a/server/game/cards/02.3-ItFC/TestOfCourage.js
+++ b/server/game/cards/02.3-ItFC/TestOfCourage.js
@@ -15,7 +15,7 @@ class TestOfCourage extends DrawCard {
                 this.game.addMessage('{0} plays {1}, moving {2} into conflict', this.controller, this, context.target);
                 let honorEvent = {
                     name: 'onCardHonored',
-                    params: { player: this.controller, card: context.target, source: this },
+                    params: { player: this.controller, card: context.target, source: this, gameAction: 'honor' },
                     handler: event => event.card.honor()
                 };
                 let moveEvent = {
@@ -28,7 +28,6 @@ class TestOfCourage extends DrawCard {
                             event.conflict.addDefender(event.card);
                         }
                         this.game.addMessage('{0} honors {1}', this, event.card);                        
-                        return { resolved: true, success: true };
                     }
                 };
                 this.game.raiseMultipleEvents([moveEvent], {

--- a/server/game/cards/02.5-FHNS/AFateWorseThanDeath.js
+++ b/server/game/cards/02.5-FHNS/AFateWorseThanDeath.js
@@ -15,18 +15,14 @@ class AFateWorseThanDeath extends DrawCard {
                     events.push({
                         name: 'onCardBowed',
                         params: { card: context.target, source: this, gameAction: 'bow' },
-                        handler: () => {
-                            return { resolved: true, success: context.target.bow() };
-                        }
+                        handler: () => context.target.bow()
                     });
                 }
                 if(context.target.allowGameAction('dishonor', context)) {
                     events.push({
                         name: 'onCardDishonored',
                         params: { card: context.target, source: this, gameAction: 'dishonor' },
-                        handler: () => {
-                            return { resolved: true, success: context.target.dishonor() };
-                        }
+                        handler: () => context.target.dishonor()
                     });
                 }
                 if(context.target.allowGameAction('removeFate', context)) {

--- a/server/game/conflict.js
+++ b/server/game/conflict.js
@@ -154,7 +154,6 @@ class Conflict {
             } else {
                 this.resolveConflictRing(player, optional);
             }
-            return { resolved: true, success: true };        
         });
     }
     

--- a/server/game/gamesteps/DuelFlow.js
+++ b/server/game/gamesteps/DuelFlow.js
@@ -49,10 +49,7 @@ class DuelFlow extends BaseStepWithPipeline {
 
     applyDuelResults() {
         if(this.duel.winner) {
-            this.game.raiseEvent('onDuelResolution', { duel: this.duel }, () => {
-                this.resolutionHandler(this.duel.winner, this.duel.loser);
-                return { resolved: true, success: true };
-            });
+            this.game.raiseEvent('onDuelResolution', { duel: this.duel }, () => this.resolutionHandler(this.duel.winner, this.duel.loser));
         }
     }
 

--- a/server/game/gamesteps/ThenEventWindow.js
+++ b/server/game/gamesteps/ThenEventWindow.js
@@ -17,7 +17,7 @@ class ThenEventWindow extends EventWindow {
     }
 
     filterUnsuccessfulEvents() {
-        this.events = _.filter(this.events, event => event.parentEvent.result.success);
+        this.events = _.reject(this.events, event => event.parentEvent.cancelled);
     }
 }
 

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -322,11 +322,7 @@ class ConflictFlow extends BaseStepWithPipeline {
             return;
         }
         if(this.conflict.winner) {
-            this.game.raiseEvent('onClaimRing', { player: this.conflict.winner, conflict: this.conflict }, () => {
-                ring.claimRing(this.conflict.winner);
-                return { resolved: true, success: true };
-            });
-
+            this.game.raiseEvent('onClaimRing', { player: this.conflict.winner, conflict: this.conflict }, () => ring.claimRing(this.conflict.winner));
         }
         //Do this lazily for now
         ring.contested = false;

--- a/server/game/gamesteps/fatephase.js
+++ b/server/game/gamesteps/fatephase.js
@@ -44,10 +44,7 @@ class FatePhase extends Phase {
     }
     
     placeFateOnUnclaimedRings() {
-        this.game.raiseEvent('onPlaceFateOnUnclaimedRings', {}, () => {
-            this.game.placeFateOnUnclaimedRings();
-            return { resolved: true, success: true };
-        });
+        this.game.raiseEvent('onPlaceFateOnUnclaimedRings', {}, () => this.game.placeFateOnUnclaimedRings());
     }
 }
 

--- a/server/game/gamesteps/regroupphase.js
+++ b/server/game/gamesteps/regroupphase.js
@@ -34,7 +34,6 @@ class RegroupPhase extends Phase {
             _.each(this.game.getPlayers(), player => {
                 player.readyCards();
             });
-            return { resolved: true, success: true };
         });
     }
     
@@ -93,20 +92,14 @@ class RegroupPhase extends Phase {
     }
     
     returnRings() {
-        this.game.raiseEvent('onReturnRings', {}, () => {
-            this.game.returnRings();
-            return { resolved: true, success: true };
-        });
+        this.game.raiseEvent('onReturnRings', {}, () => this.game.returnRings());
     }
 
     passFirstPlayer() {
         let firstPlayer = this.game.getFirstPlayer();
         let otherPlayer = this.game.getOtherPlayer(firstPlayer);
         if(otherPlayer) {
-            this.game.raiseEvent('onPassFirstPlayer', { player: otherPlayer }, () => {
-                this.game.setFirstPlayer(otherPlayer);
-                return { resolved: true, success: true };
-            });
+            this.game.raiseEvent('onPassFirstPlayer', { player: otherPlayer }, () => this.game.setFirstPlayer(otherPlayer));
         }
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1451,7 +1451,6 @@ class Player extends Spectator {
             } else if(event.card.isDynasty) {
                 this.moveCard(event.card, 'dynasty discard pile');
             }
-            return { resolved: true, success: true };
         });
     }
 
@@ -1685,7 +1684,6 @@ class Player extends Spectator {
                     }
                 }
             }
-            return { resolved: true, success: true };
         });
     }
 
@@ -1695,9 +1693,7 @@ class Player extends Spectator {
      * @param {EffectSource} source
      */
     honorCard(card, source) {
-        this.game.raiseEvent('onCardHonored', { player: this, card: card, source: source }, () => {
-            return { resolved: true, success: card.honor() };
-        });
+        this.game.raiseEvent('onCardHonored', { player: this, card: card, source: source }, () => card.honor());
     }
 
     /**
@@ -1706,9 +1702,7 @@ class Player extends Spectator {
      * @param {EffectSource} source
      */
     dishonorCard(card, source) {
-        this.game.raiseEvent('onCardDishonored', { player: this, card: card, source: source }, () => {
-            return { resolved: true, result: card.dishonor() };
-        });
+        this.game.raiseEvent('onCardDishonored', { player: this, card: card, source: source }, () => card.dishonor());
     }
 
     /**

--- a/test/server/cards/02.3-ItFC/BayushiKachiko.spec.js
+++ b/test/server/cards/02.3-ItFC/BayushiKachiko.spec.js
@@ -1,0 +1,116 @@
+const AbilityDsl = require('../../../../server/game/abilitydsl.js');
+
+describe('Bayushi Kachiko', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['bayushi-kachiko']
+                },
+                player2: {
+                    inPlay: ['shrewd-yasuki', 'borderlands-defender']
+                }
+            });
+            this.noMoreActions();
+        });
+
+        describe('her ability', function() {
+            beforeEach(function() {
+                this.initiateConflict({
+                    type: 'political',
+                    attackers: ['bayushi-kachiko'],
+                    defenders: ['shrewd-yasuki', 'borderlands-defender']
+                });
+                this.player2.clickPrompt('Pass');
+                this.player1.clickCard('bayushi-kachiko');
+            });
+
+            it('should not be able to target a character who cannot be sent home', function() {
+                this.borderlandsDefender = this.player2.findCardByName('borderlands-defender');
+                expect(this.player1).not.toBeAbleToSelect(this.borderlandsDefender);
+            });
+
+            it('should send an defender home', function() {
+                this.shrewdYasuki = this.player1.clickCard('shrewd-yasuki', 'any', 'opponent');
+                expect(this.shrewdYasuki.inConflict).toBe(false);
+                expect(this.game.currentConflict.defenders).not.toContain(this.shrewdYasuki);
+            });
+
+            it('should give Kachiko\'s controller the option to bow the target', function() {
+                this.shrewdYasuki = this.player1.clickCard('shrewd-yasuki', 'any', 'opponent');
+                expect(this.player1).toHavePrompt('Do you want to bow Shrewd Yasuki?');
+            });
+            
+            it('should bow the target if Yes is selected', function() {
+                this.shrewdYasuki = this.player1.clickCard('shrewd-yasuki', 'any', 'opponent');
+                this.player1.clickPrompt('Yes');
+                expect(this.shrewdYasuki.bowed).toBe(true);
+            });
+
+            it('should not bow the target if No is selected', function() {
+                this.shrewdYasuki = this.player1.clickCard('shrewd-yasuki', 'any', 'opponent');
+                this.player1.clickPrompt('No');
+                expect(this.shrewdYasuki.bowed).toBe(false);
+            });
+        });
+
+        describe('if her ability is used and the target is not sent home', function() {
+            it('her controller should not be prompted to bow the target', function() {
+                this.initiateConflict({
+                    type: 'political',
+                    attackers: ['bayushi-kachiko'],
+                    defenders: ['shrewd-yasuki', 'borderlands-defender']
+                });
+                this.shrewdYasuki = this.player2.findCardByName('shrewd-yasuki');
+                // Give Yasuki a hypothetical ability which cancels send homes
+                this.shrewdYasuki.interrupt({
+                    title: 'Cancel Send Home',
+                    when: {
+                        onSendHome: event => event.card === this.shrewdYasuki
+                    },
+                    canCancel: true,
+                    handler: context => context.cancel()
+                });
+                this.shrewdYasuki.abilities.reactions[0].registerEvents();
+                this.game.registerAbility(this.shrewdYasuki.abilities.reactions[0]);
+                this.player2.clickPrompt('Pass');
+                this.player1.clickCard('bayushi-kachiko');
+                this.player1.clickCard(this.shrewdYasuki);
+
+                expect(this.player2).toHavePrompt('Any interrupts?');
+                this.player2.clickCard(this.shrewdYasuki);
+
+                expect(this.shrewdYasuki.inConflict).toBe(true);
+                expect(this.game.currentConflict.defenders).toContain(this.shrewdYasuki);
+                expect(this.player1).not.toHavePrompt('Do you want to bow Shrewd Yasuki?');
+            });
+        });
+
+        describe('if her ability is used and the target can be sent home but not bowed', function() {
+            it('her controller should not be prompted to bow the target', function() {
+                this.initiateConflict({
+                    type: 'political',
+                    attackers: ['bayushi-kachiko'],
+                    defenders: ['shrewd-yasuki', 'borderlands-defender']
+                });
+                this.shrewdYasuki = this.player2.findCardByName('shrewd-yasuki');
+                // Give Yasuki a hypothetical ability so it cannot be bowed
+                this.shrewdYasuki.persistentEffect({
+                    match: this.shrewdYasuki,
+                    effect: AbilityDsl.effects.cannotBeBowed()
+                });
+                this.game.addEffect(this.shrewdYasuki, this.shrewdYasuki.abilities.persistentEffects[0]);
+                expect(this.shrewdYasuki.allowGameAction('bow')).toBe(false);
+
+                this.player2.clickPrompt('Pass');
+                this.player1.clickCard('bayushi-kachiko');
+                this.player1.clickCard(this.shrewdYasuki);
+
+                expect(this.shrewdYasuki.inConflict).toBe(false);
+                expect(this.game.currentConflict.defenders).not.toContain(this.shrewdYasuki);
+                expect(this.player1).not.toHavePrompt('Do you want to bow Shrewd Yasuki?');
+            });
+        });
+    });
+});


### PR DESCRIPTION
A long standing problem with the game engine is that there is no way to track whether an effect has resolved successfully, or a cost has been successfully paid.  I partially implemented a fix for this where event handlers returned a result object so that the game could verify that the handler had resolved, but I don't think this is the best way to solve this particular issue, so this PR removes some ground work I did for it.

I also used this system for thenEvents, so I've refactored thoses and rewritten Bayushi Kachiko.  Test for Bayushi Kachiko also included