### PR TITLE
Remove event params hack and uuids

### DIFF
--- a/server/game/Events/Event.js
+++ b/server/game/Events/Event.js
@@ -1,5 +1,4 @@
 const _ = require('underscore');
-const uuid = require('uuid');
 
 class Event {
     constructor(name, params, handler) {
@@ -10,10 +9,8 @@ class Event {
         this.thenEvents = [];
         this.parentEvent = null;
         this.result = { resolved: false, success: false};
-        this.uuid = uuid.v1();
 
         _.extend(this, params);
-        this.params = [this].concat(params);
         if(!this.order) {
             this.order = 0;
         }
@@ -45,7 +42,7 @@ class Event {
     
     executeHandler() {
         if(this.handler) {
-            this.result = this.handler(...this.params) || { resolved: true, success: true};
+            this.result = this.handler(this) || { resolved: true, success: true};
         }
     }
 

--- a/server/game/gamesteps/EventWindow.js
+++ b/server/game/gamesteps/EventWindow.js
@@ -35,9 +35,8 @@ class EventWindow extends BaseStepWithPipeline {
         if(!_.isArray(events)) {
             events = [events];
         }
-        let uuids = events.map(event => event.uuid);
         _.each(events, event => event.unsetWindow());
-        this.events = _.reject(this.events, event => uuids.includes(event.uuid));
+        this.events = _.difference(this.events, events);
         _.each(this.events, event => event.checkCondition());
     }
 
@@ -54,7 +53,7 @@ class EventWindow extends BaseStepWithPipeline {
     
     // This catches any persistent/delayed effect cancels
     checkForOtherEffects() {
-        _.each(this.events, event => this.game.emit(event.name + 'OtherEffects', ...event.params));
+        _.each(this.events, event => this.game.emit(event.name + 'OtherEffects', event));
     }
 
     preResolutionEffects() {
@@ -76,7 +75,7 @@ class EventWindow extends BaseStepWithPipeline {
 
                 this.game.queueSimpleStep(() => {
                     event.executeHandler();
-                    this.game.emit(event.name, ...event.params);
+                    this.game.emit(event.name, event);
                 });
             }
         });

--- a/server/game/gamesteps/baseabilitywindow.js
+++ b/server/game/gamesteps/baseabilitywindow.js
@@ -16,7 +16,7 @@ class BaseAbilityWindow extends BaseStep {
 
     emitEvents() {
         _.each(this.events, event => {
-            this.game.emit(event.name + ':' + this.abilityType, ...event.params);
+            this.game.emit(event.name + ':' + this.abilityType, event);
         });
     }
 

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -38,7 +38,7 @@ class TriggeredAbility extends CardAbility {
             return false;
         }
 
-        return listener(...event.params);
+        return listener(event);
     }
 
     meetsRequirements(context) {

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -35,7 +35,7 @@ describe('CardForcedReaction', function () {
 
         it('should call the when handler with the appropriate arguments', function() {
             this.executeEventHandler(1, 2, 3);
-            expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event, 1, 2, 3);
+            expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event);
         });
 
         describe('when the when condition returns false', function() {
@@ -73,7 +73,7 @@ describe('CardForcedReaction', function () {
 
         it('should call the when handler with the appropriate arguments', function() {
             this.meetsRequirements();
-            expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event, 1, 2, 3);
+            expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event);
         });
 
         xdescribe('when in the setup phase', function() {

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -45,7 +45,7 @@ describe('CardReaction', function () {
 
         it('should call the when handler with the appropriate arguments', function() {
             this.executeEventHandler(1, 2, 3);
-            expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event, 1, 2, 3);
+            expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event);
         });
 
         describe('when the when condition returns false', function() {
@@ -83,7 +83,7 @@ describe('CardReaction', function () {
 
         it('should call the when handler with the appropriate arguments', function() {
             this.meetsRequirements();
-            expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event, 1, 2, 3);
+            expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event);
         });
 
         xdescribe('when in the setup phase', function() {


### PR DESCRIPTION
More code clean up.  Events have always had a slightly wierd hack to their parameters - I think throneteki needs this for backwards-compatibility but we don't so I've removed it.

Events also no longer need a uuid, so that has also been removed