### PR TITLE
Tests discard piles

### DIFF
--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -135,26 +135,24 @@ global.integration = function(definitions) {
                 if(options.player2.rings) {
                     _.each(options.player2.rings, ring => this.player2.claimRing(ring));
                 }
+                //Player stats
                 this.player1.fate = options.player1.fate;
                 this.player2.fate = options.player2.fate;
                 this.player1.honor = options.player1.honor;
                 this.player2.honor = options.player2.honor;
+                //Field
                 this.player1.inPlay = options.player1.inPlay;
                 this.player2.inPlay = options.player2.inPlay;
+                //Conflict deck related
                 this.player1.hand = options.player1.hand;
                 this.player2.hand = options.player2.hand;
-                this.player1.dynastyDiscardPile = options.player1.dynastyDiscard;
-                this.player2.dynastyDiscardPile = options.player2.dynastyDiscard;
                 this.player1.conflictDiscard = options.player1.conflictDiscard;
                 this.player2.conflictDiscard = options.player2.conflictDiscard;
-
-                // If a province setup has been specified (i.e. provinces is an Object, not an Array), set them up
-                if(!_.isArray(options.player1.provinces)) {
-                    this.player1.provinces = options.player1.provinces;
-                }
-                if(!_.isArray(options.player2.provinces)) {
-                    this.player2.provinces = options.player2.provinces;
-                }
+                //Dynsaty deck related
+                this.player1.provinces = options.player1.provinces;
+                this.player2.provinces = options.player2.provinces;
+                this.player1.dynastyDiscard = options.player1.dynastyDiscard;
+                this.player2.dynastyDiscard = options.player2.dynastyDiscard;
             };
 
             this.initiateConflict = function(options = {}) {

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -106,7 +106,18 @@ class PlayerInteractionWrapper {
     */
     set provinces(newProvinceState) {
         if(!newProvinceState) {
-            return;
+            newProvinceState = {};
+        }
+        // If function recieves an array of province cards, adapt it into an
+        // object
+        if(!_.isArray(newProvinceState)) {
+            let provincesObject = {};
+            _.each(newProvinceState, (card, index) => {
+                provincesObject[`province ${index}`] = {
+                    provinceCard: card
+                }
+            });
+            newProvinceState = provincesObject;
         }
         //Move all cards from all provinces to decks
         var allProvinceLocations = _.keys(this.provinces);
@@ -265,8 +276,9 @@ class PlayerInteractionWrapper {
         _.each(this.dynastyDiscard, card => {
             this.moveCard(card, 'dynasty deck');
         });
-        // Move cards to the discard
-        _.each(newContents, name => {
+        // Move cards to the discard in reverse order
+        // (helps with referencing cards in tests by index)
+        _.chain(newContents).reverse().each(name => {
             var card = this.findCardByName(name, 'dynasty deck');
             this.moveCard(card, 'dynasty discard pile');
         });

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -252,8 +252,9 @@ class PlayerInteractionWrapper {
         _.each(this.conflictDiscard, card => {
             this.moveCard(card, 'conflict deck');
         });
-        // Move cards to the discard
-        _.each(newContents, name => {
+        // Move cards to the discard in reverse order
+        // (helps with referring to cards by index)
+        _.chain(newContents).reverse().each(name => {
             var card = this.findCardByName(name, 'conflict deck');
             this.moveCard(card, 'conflict discard pile');
         });


### PR DESCRIPTION
with this change the default for provinces is to not contain any dynasty cards, so that dynasty discard can be set properly, and cards in discard piles appear the same way as specified in test options (so can be referred by index)