### PR TITLE
property name change in conflict.js

### DIFF
--- a/server/game/conflict.js
+++ b/server/game/conflict.js
@@ -29,7 +29,7 @@ class Conflict {
     }
 
     singlePlayerDefender() {
-        let dummyPlayer = new Player('', Settings.getUserWithDefaultsSet({ name: 'Dummy Player' }), false, this.game);
+        let dummyPlayer = new Player('', Settings.getUserWithDefaultsSet({ username: 'Dummy Player' }), false, this.game);
         dummyPlayer.initialise();
         return dummyPlayer;
     }


### PR DESCRIPTION
changed property in singlePlayerDefender that was causing unnecessary messages to pop up on a passed conflict