### PR TITLE
refactor findAndUseAction into initiateCardAction

### DIFF
--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -184,7 +184,6 @@ const Costs = {
                 return true; // We have to check this condition in Ability.meetsRequirements(), or we risk players starting another ability while costs are resolving
             },
             pay: function(context) {
-                context.player.canInitiateAction = false;
                 context.game.markActionAsTaken();
             },
             canIgnoreForTargeting: true

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -319,25 +319,6 @@ class Game extends EventEmitter {
             this.selectProvince(player, cardId);
             return;
         }
-
-        // Check if the card itself is waiting for a click
-        if(card.onClick(player)) {
-            return;
-        }
-
-        // Look for actions or play actions for this card
-        if(player.findAndUseAction(card)) {
-            return;
-        }
-
-        /* This doesn't really work with cards which trigger from being flipped
-        // If it's the Dynasty phase, and this is a Dynasty card in a province, flip it face up
-        if(['province 1', 'province 2', 'province 3', 'province 4'].includes(card.location) && card.controller === player && card.isDynasty) {
-            if(card.facedown && this.currentPhase === 'dynasty') {
-                card.facedown = false;
-                this.addMessage('{0} reveals {1}', player, card);
-            }
-        }*/
     }
 
     /*
@@ -386,10 +367,7 @@ class Game extends EventEmitter {
         if(this.pipeline.handleCardClicked(player, card)) {
             return;
         }
-
-        // Look for actions or play actions for this card
-        player.findAndUseAction(card);
-    }
+   }
 
     /*
      * Resets all the rings to unclaimed

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -367,7 +367,7 @@ class Game extends EventEmitter {
         if(this.pipeline.handleCardClicked(player, card)) {
             return;
         }
-   }
+    }
 
     /*
      * Resets all the rings to unclaimed

--- a/server/game/gamesteps/actionwindow.js
+++ b/server/game/gamesteps/actionwindow.js
@@ -22,6 +22,13 @@ class ActionWindow extends UiPrompt {
         return player === this.currentPlayer;
     }
 
+    onCardClicked(player, card) {
+        if(player !== this.currentPlayer) {
+            return false;
+        }
+        player.initiateCardAction(card);
+    }
+
     continue() {
         if(!this.currentPlayer.promptedActionWindows[this.windowName]) {
             this.pass();
@@ -34,7 +41,6 @@ class ActionWindow extends UiPrompt {
 
         if(!completed) {
             this.game.currentActionWindow = this;
-            this.currentPlayer.canInitiateAction = true;
         } else {
             this.game.currentActionWindow = null;
         }
@@ -60,8 +66,6 @@ class ActionWindow extends UiPrompt {
     }
 
     menuCommand(player, choice) {
-        player.canInitiateAction = false;
-
         if(choice === 'manual') {
             this.game.promptForSelect(this.currentPlayer, {
                 source: 'Manual Action',

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -66,7 +66,6 @@ class Player extends Spectator {
         this.cannotGainConflictBonus = false; // I have no idea what this is for
         this.abilityRestrictions = []; // This stores player restrictions from e.g. Guest of Honor
         this.abilityMaxByIdentifier = {}; // This records max limits for abilities
-        this.canInitiateAction = false; // This flag determines whether this player has priority in an action window
         this.conflictDeckTopCardHidden = true;
         this.promptedActionWindows = user.promptedActionWindows || { // these flags represent phase settings
             dynasty: true,
@@ -873,8 +872,8 @@ class Player extends Spectator {
      * their requirements.  If only one does, calls that ability, if more than one do, prompts the player to pick one
      * @param {BaseCard} card
      */
-    findAndUseAction(card) {
-        if(!card || !this.canInitiateAction) {
+    initiateCardAction(card) {
+        if(!card) {
             return false;
         }
 
@@ -891,7 +890,6 @@ class Player extends Spectator {
             return false;
         }
 
-        this.canInitiateAction = false;
         if(contexts.length === 1) {
             this.game.resolveAbility(contexts[0]);
         } else {

--- a/test/server/card/drawcard.hasKeyword.spec.js
+++ b/test/server/card/drawcard.hasKeyword.spec.js
@@ -64,7 +64,7 @@ describe('the DrawCard', function() {
                     this.card = new DrawCard(this.player, { text: 'Each <i>Covert</i> character you control cannot be bypassed by covert.' });
                     this.card.location = 'hand';
                     this.player.hand = _([this.card]);
-                    this.player.findAndUseAction(this.card);
+                    this.player.initiateCardAction(this.card);
                     // Resolve events in pipeline.
                     this.game.continue();
                 });

--- a/test/server/cards/01-Core/Blackmail.spec.js
+++ b/test/server/cards/01-Core/Blackmail.spec.js
@@ -34,7 +34,7 @@ describe('Blackmail', function() {
                 this.player1.clickCard('blackmail');
 
                 expect(this.player1).not.toHavePrompt('Choose a character');
-                expect(this.player1.player.canInitiateAction).toBe(true);
+                expect(this.game.currentActionWindow).not.toBe(null);
             });
 
             it('should allow characters with cost under 3 in the conflict to be chosen', function() {

--- a/test/server/cards/01-Core/CallingInFavors.spec.js
+++ b/test/server/cards/01-Core/CallingInFavors.spec.js
@@ -68,7 +68,7 @@ describe('Calling In Favors', function() {
                     this.fineKatana = this.player1.playAttachment('fine-katana', 'adept-of-the-waves');
                     this.player2.clickCard('calling-in-favors', 'hand');
 
-                    expect(this.player2.player.canInitiateAction).toBe(true);
+                    expect(this.game.currentActionWindow).not.toBe(null);
                     expect(this.player2).not.toHavePrompt('Choose an attachment');
                 });
             });

--- a/test/server/cards/01-Core/Charge.spec.js
+++ b/test/server/cards/01-Core/Charge.spec.js
@@ -62,7 +62,7 @@ describe('Charge!', function() {
                         this.player1.clickCard('charge', 'hand');
 
                         expect(this.player1).not.toHavePrompt('Choose a character');
-                        expect(this.player1.player.canInitiateAction).toBe(true);
+                        expect(this.game.currentActionWindow).not.toBe(null);
                     });
                 });
             });

--- a/test/server/dynastycardaction.spec.js
+++ b/test/server/dynastycardaction.spec.js
@@ -28,7 +28,6 @@ describe('DynastyCardAction', function () {
             this.gameSpy.currentPhase = 'dynasty';
             this.playerSpy.isCardInPlayableLocation.and.returnValue(true);
             this.playerSpy.getReducedCost.and.returnValue(0);
-            this.playerSpy.canInitiateAction = true;
             this.cardSpy.getType.and.returnValue('character');
             this.cardSpy.canPlay.and.returnValue(true);
             this.cardSpy.isLimited.and.returnValue(false);

--- a/test/server/player/playcard.spec.js
+++ b/test/server/player/playcard.spec.js
@@ -5,10 +5,9 @@ describe('Player', function() {
         this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'getOtherPlayer', 'playerDecked', 'resolveAbility', 'queueStep', 'raiseEvent', 'promptWithHandlerMenu']);
         this.player = new Player('1', {username: 'Player 1', settings: {}}, true, this.gameSpy);
         this.player.initialise();
-        this.player.canInitiateAction = true;
     });
 
-    describe('findAndUseAction', function() {
+    describe('initiateCardAction', function() {
         beforeEach(function() {
             this.playActionSpy = jasmine.createSpyObj('playAction', ['meetsRequirements', 'canPayCosts', 'canResolveTargets']);
             this.cardSpy = jasmine.createSpyObj('card', ['getActions']);
@@ -22,7 +21,7 @@ describe('Player', function() {
         describe('when card is undefined', function() {
             beforeEach(function() {
                 this.player.hand.pop();
-                this.canPlay = this.player.findAndUseAction(undefined);
+                this.canPlay = this.player.initiateCardAction(undefined);
             });
 
             it('should return false', function() {
@@ -47,12 +46,12 @@ describe('Player', function() {
                 });
 
                 it('should resolve the play action', function() {
-                    this.player.findAndUseAction(this.cardSpy);
+                    this.player.initiateCardAction(this.cardSpy);
                     expect(this.gameSpy.resolveAbility).toHaveBeenCalledWith(jasmine.objectContaining({ game: this.gameSpy, player: this.player, source: this.cardSpy, ability: this.playActionSpy }));
                 });
 
                 it('should return true', function() {
-                    expect(this.player.findAndUseAction(this.cardSpy)).toBe(true);
+                    expect(this.player.initiateCardAction(this.cardSpy)).toBe(true);
                 });
             });
 
@@ -64,12 +63,12 @@ describe('Player', function() {
                 });
 
                 it('should not resolve the play action', function() {
-                    this.player.findAndUseAction(this.cardSpy);
+                    this.player.initiateCardAction(this.cardSpy);
                     expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
                 });
 
                 it('should return false', function() {
-                    expect(this.player.findAndUseAction(this.cardSpy)).toBe(false);
+                    expect(this.player.initiateCardAction(this.cardSpy)).toBe(false);
                 });
             });
 
@@ -81,12 +80,12 @@ describe('Player', function() {
                 });
 
                 it('should not resolve the play action', function() {
-                    this.player.findAndUseAction(this.cardSpy);
+                    this.player.initiateCardAction(this.cardSpy);
                     expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
                 });
 
                 it('should return false', function() {
-                    expect(this.player.findAndUseAction(this.cardSpy)).toBe(false);
+                    expect(this.player.initiateCardAction(this.cardSpy)).toBe(false);
                 });
             });
 
@@ -98,12 +97,12 @@ describe('Player', function() {
                 });
 
                 it('should not resolve the play action', function() {
-                    this.player.findAndUseAction(this.cardSpy);
+                    this.player.initiateCardAction(this.cardSpy);
                     expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
                 });
 
                 it('should return false', function() {
-                    expect(this.player.findAndUseAction(this.cardSpy)).toBe(false);
+                    expect(this.player.initiateCardAction(this.cardSpy)).toBe(false);
                 });
             });
         });
@@ -121,12 +120,12 @@ describe('Player', function() {
             });
 
             it('should prompt the player to choose a play action', function() {
-                this.player.findAndUseAction(this.cardSpy);
+                this.player.initiateCardAction(this.cardSpy);
                 expect(this.gameSpy.promptWithHandlerMenu).toHaveBeenCalledWith(this.player, jasmine.objectContaining({ activePromptTitle: 'Play Card:' }));
             });
 
             it('should return true', function() {
-                expect(this.player.findAndUseAction(this.cardSpy)).toBe(true);
+                expect(this.player.initiateCardAction(this.cardSpy)).toBe(true);
             });
         });
     });


### PR DESCRIPTION
- card actions are handled by the relevant action window instead of being called directly by Game
- removed canInitiateAction as a player variable as it's no longer necessary
- Fixes bugs with abilities double triggering, and passing priority being skipped during action phases