### PR TITLE
Bugfix for Test of Skill, Shrine Maiden

### DIFF
--- a/server/game/GameActions/RevealAction.js
+++ b/server/game/GameActions/RevealAction.js
@@ -9,7 +9,8 @@ class RevealAction extends CardGameAction {
     }
 
     canAffect(card, context) {
-        if(!card.facedown && card.location !== 'hand') {
+        let testLocations = ['province 1', 'province 2', 'province 3', 'province 4', 'stronghold province','play area'];
+        if(!card.facedown && testLocations.includes(card.location)) {
             return false;
         }
         return super.canAffect(card, context);

--- a/server/game/cards/02.5-FHNS/TestOfSkill.js
+++ b/server/game/cards/02.5-FHNS/TestOfSkill.js
@@ -33,7 +33,7 @@ class TestOfSkill extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Reveal cards and take ones matching named type',
-            condition: context => context.player.conflictDeck.size() >= context.player.cardsInPlay.some(card => card.hasTrait('duelist')) ? 3 : 4,
+            condition: context => context.player.conflictDeck.size() >= context.player.cardsInPlay.some(card => card.hasTrait('duelist')) ? 4 : 3,
             cost: [ability.costs.revealCards(context => context.player.conflictDeck.first(
                 context.player.cardsInPlay.some(card => card.hasTrait('duelist')) ? 4 : 3
             )), testOfSkillCost()],
@@ -41,6 +41,9 @@ class TestOfSkill extends DrawCard {
             effect: 'take cards into their hand',
             handler: context => {
                 let [matchingCards, cardsToDiscard] = _.partition(context.costs.reveal, card => card.type === context.costs.testOfSkillCost && card.location === 'conflict deck');
+                //Handle situations where card is played from deck, such as with pillow book
+                matchingCards = _.reject(matchingCards, c=> c.uuid === context.source.uuid);
+
                 let discardHandler = () => {
                     cardsToDiscard = cardsToDiscard.concat(matchingCards);
                     this.game.addMessage('{0} discards {1}', context.player, cardsToDiscard);

--- a/server/game/cards/02.5-FHNS/TestOfSkill.js
+++ b/server/game/cards/02.5-FHNS/TestOfSkill.js
@@ -33,9 +33,9 @@ class TestOfSkill extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Reveal cards and take ones matching named type',
-            condition: context => context.player.conflictDeck.size() >= context.player.cardsInPlay.any(card => card.hasTrait('duelist')) ? 3 : 4,
+            condition: context => context.player.conflictDeck.size() >= context.player.cardsInPlay.some(card => card.hasTrait('duelist')) ? 3 : 4,
             cost: [ability.costs.revealCards(context => context.player.conflictDeck.first(
-                context.player.cardsInPlay.any(card => card.hasTrait('duelist')) ? 3 : 4
+                context.player.cardsInPlay.some(card => card.hasTrait('duelist')) ? 4 : 3
             )), testOfSkillCost()],
             cannotBeMirrored: true,
             effect: 'take cards into their hand',

--- a/server/game/cards/02.6-MotE/PillowBook.js
+++ b/server/game/cards/02.6-MotE/PillowBook.js
@@ -4,7 +4,7 @@ class PillowBook extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Make top card of your conflict deck playable',
-            condition: context => context.source.isParticipating() && context.player.conflictDeck.size() > 0,
+            condition: context => context.source.parent.isParticipating() && context.player.conflictDeck.size() > 0,
             effect: 'make the top card of their deck playable until the end of the conflict',
             gameAction: ability.actions.playerLastingEffect(context => ({
                 duration: 'lastingEffect',

--- a/server/game/costs/SpecificCardCost.js
+++ b/server/game/costs/SpecificCardCost.js
@@ -6,6 +6,14 @@ class SpecificCardCost {
 
     canPay(context) {
         let card = this.cardFunc(context);
+        //handle cases where "card" is actually an array of cards
+        if(card.length !== undefined && card.length > 0) {
+            let result = true;
+            card.forEach((subcard) => {
+                result = result && this.action.canAffect(subcard);
+            });
+            return result;
+        }
         return this.action.canAffect(card, context);
     }
 


### PR DESCRIPTION
- Specific card costs now support Arrays from CardFunc
- Reveal GameAction now validates against a list of locations instead of not-in-hand
- Test of Skill now using array.some() and ternary no longer reversed