### PR TITLE
Bug fix for 'opponent's card effects'

### DIFF
--- a/server/game/cards/01-Core/AboveQuestion.js
+++ b/server/game/cards/01-Core/AboveQuestion.js
@@ -3,7 +3,7 @@ const DrawCard = require('../../drawcard.js');
 class AboveQuestion extends DrawCard {
     setupCardAbilities(ability) {
         this.whileAttached({
-            effect: ability.effects.cardCannot('target', context => context && context.source.type === 'event' && context.source.controller === this.controller.opponent)
+            effect: ability.effects.cardCannot('target', context => context && context.source.type === 'event' && context.player === this.controller.opponent)
         });
     }
 }

--- a/server/game/cards/01-Core/BorderlandsDefender.js
+++ b/server/game/cards/01-Core/BorderlandsDefender.js
@@ -6,8 +6,8 @@ class BorderlandsDefender extends DrawCard {
             match: this,
             condition: () => this.isDefending(),
             effect: [
-                ability.effects.cardCannot('sendHome', context => context && context.source.controller === this.controller.opponent),
-                ability.effects.cardCannot('bow', context => context && context.source.type !== 'ring' && context.source.controller === this.controller.opponent)
+                ability.effects.cardCannot('sendHome', context => context && context.player === this.controller.opponent),
+                ability.effects.cardCannot('bow', context => context && context.source.type !== 'ring' && context.player === this.controller.opponent)
             ]
         });
     }

--- a/server/game/cards/01-Core/ReadyForBattle.js
+++ b/server/game/cards/01-Core/ReadyForBattle.js
@@ -6,7 +6,7 @@ class ReadyForBattle extends DrawCard {
             title: 'Ready a character',
             when: {
                 onCardBowed: (event, context) => event.card.controller === context.player && (event.context.source.type === 'ring' ||
-                                                 context.player.opponent && event.context.source.controller === context.player.opponent)
+                                                 context.player.opponent && event.context.player === context.player.opponent)
             },
             cannotBeMirrored: true,
             gameAction: ability.actions.ready(context => ({ target: context.event.card }))

--- a/server/game/cards/03-DotV/ClarityOfPurpose.js
+++ b/server/game/cards/03-DotV/ClarityOfPurpose.js
@@ -16,7 +16,7 @@ class ClarityOfPurpose extends DrawCard {
                     ability.actions.cardLastingEffect(context => ({
                         effect: ability.effects.cardCannot('bow', abilityContext => (
                             abilityContext.source.type !== 'ring' && context.player.opponent &&
-                            abilityContext.source.controller === context.player.opponent
+                            abilityContext.player === context.player.opponent
                         ))
                     }))
                 ]

--- a/server/game/cards/03-DotV/KaitoTempleProtector.js
+++ b/server/game/cards/03-DotV/KaitoTempleProtector.js
@@ -5,7 +5,7 @@ class KaitoTempleProtector extends DrawCard {
         this.persistentEffect({
             condition: () => this.isDefending(),
             match: this,
-            effect: ability.effects.cardCannot('sendHome', context => context.source.controller === this.controller.opponent)
+            effect: ability.effects.cardCannot('sendHome', context => context.player === this.controller.opponent)
         });
         this.action({
             title: 'Change base skills to match another character\'s',


### PR DESCRIPTION
Abilities which look for 'opponent's card effects' usually use `context.source.controller`.

However, The Mirror's Gaze means that a player can use an event which their opponent controls, but it's considered to be their card effect. Changed these abilities to use `context.player` instead