### PR TITLE
Create ApplyUnopposedAction so it can be interrupted

### DIFF
--- a/server/game/GameActions/ApplyUnopposedAction.js
+++ b/server/game/GameActions/ApplyUnopposedAction.js
@@ -1,0 +1,20 @@
+const LoseHonorAction = require('./LoseHonorAction');
+
+class ApplyUnopposedAction extends LoseHonorAction {
+    setup() {
+        super.setup();
+        this.name = 'applyUnopposed';
+        this.effectMsg = '{0} loses ' + this.amount + ' honor for  for not defending the conflict';
+        this.cost = 'losing ' + this.amount + ' honor';
+    }
+
+    canAffect(player, context) {
+        return this.amount === 0 ? false : super.canAffect(player, context);
+    }
+
+    getEvent(player, context) {
+        return super.createEvent('onApplyUnopposed', { player: player, amount: -this.amount, context: context }, event => player.modifyHonor(event.amount));
+    }
+}
+
+module.exports = ApplyUnopposedAction;

--- a/server/game/GameActions/GameActions.js
+++ b/server/game/GameActions/GameActions.js
@@ -1,3 +1,4 @@
+const ApplyUnopposedAction = require('./ApplyUnopposedAction');
 const AttachAction = require('./AttachAction');
 const BowAction = require('./BowAction');
 const BreakAction = require('./BreakAction');
@@ -72,6 +73,7 @@ const GameActions = {
     sendHome: (propertyFactory) => new SendHomeAction(propertyFactory),
     sacrifice: (propertyFactory) => new DiscardFromPlayAction(propertyFactory, true),
     // player actions
+    applyUnopposed: (propertyFactory) => new ApplyUnopposedAction(propertyFactory), // amount = 1
     chosenDiscard: (propertyFactory) => new ChosenDiscardAction(propertyFactory), // amount = 1
     deckSearch: (propertyFactory) => new DeckSearchAction(propertyFactory), // amount = -1, reveal = true, cardCondition = (card, context) => true
     discardAtRandom: (propertyFactory) => new RandomDiscardAction(propertyFactory), // amount = 1

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -301,8 +301,7 @@ class ConflictFlow extends BaseStepWithPipeline {
         }
 
         if(this.conflict.conflictUnopposed) {
-            this.game.addMessage('{0} loses 1 honor for not defending the conflict', this.conflict.loser);
-            this.game.applyGameAction(null, { loseHonor: this.conflict.loser });
+            GameActions.applyUnopposed().resolve(this.conflict.loser, this.game.getFrameworkContext(this.conflict.loser));
         }
     }
 


### PR DESCRIPTION
This is approach to allow for the replacement effect that Ikebana Artisan introduces. From the [developer ruling](http://www.cardgamedb.com/forums/index.php?/topic/39825-ruling-ikebana-artisan/):

> It creates a replacement effect that overrides the normal rule of “unopposed -> lose 1 honor” with a new rule of “unopposed -> lose 1 fate”

By extending `LoseHonorAction` it will continue to default to a 1 honor loss, but by raising the `onApplyUnopposed` event it can now be interrupted in a similar manner to how Display of Power [replaces the default ResolveRingEffect](https://github.com/gryffon/ringteki/blob/a099bd708cc9999ccd8c7e848bacaf0d99c2edf6/server/game/cards/01-Core/DisplayOfPower.js#L13).