### PR TITLE
Add dueToUnopposed property to LoseHonorAction

### DIFF
--- a/server/game/GameActions/LoseHonorAction.js
+++ b/server/game/GameActions/LoseHonorAction.js
@@ -3,6 +3,7 @@ const PlayerAction = require('./PlayerAction');
 class LoseHonorAction extends PlayerAction {
     setDefaultProperties() {
         this.amount = 1;
+        this.dueToUnopposed = false;
     }
 
     setup() {
@@ -17,7 +18,7 @@ class LoseHonorAction extends PlayerAction {
     }
 
     getEvent(player, context) {
-        return super.createEvent('onModifyHonor', { player: player, amount: -this.amount, context: context }, event => player.modifyHonor(event.amount));
+        return super.createEvent('onModifyHonor', { player: player, amount: -this.amount, dueToUnopposed: this.dueToUnopposed, context: context }, event => player.modifyHonor(event.amount));
     }
 }
 

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -302,7 +302,7 @@ class ConflictFlow extends BaseStepWithPipeline {
 
         if(this.conflict.conflictUnopposed) {
             this.game.addMessage('{0} loses 1 honor for not defending the conflict', this.conflict.loser);
-            this.game.applyGameAction(null, { loseHonor: this.conflict.loser });
+            GameActions.loseHonor({ dueToUnopposed: true }).resolve(this.conflict.loser, this.game.getFrameworkContext(this.conflict.loser));
         }
     }
 


### PR DESCRIPTION
When losing honor due to not defending the `LoseHonorAction` will now report this reason as a `dueToUnopposed` property raised during the `onModifyHonor` event.