### PR TITLE
Test tools: get chat log(s)

### DIFF
--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -262,6 +262,47 @@ class GameFlowWrapper {
             promptedPlayer.clickPrompt('Second Player');
         }
     }
+
+    /**
+     * Get an array of the latest chat messages
+     * @param {Number} num - number of messages to retrieve, starting from the latest
+     * @param {Boolean} reverse - reverse the retrieved elements so the array is easily read when printed
+     */
+    latestChatMessages(num = 1, reverse = true) {
+        let results = [];
+        for(let i = 0; i < this.game.messages.length && i < num; i++) {
+            let result = '';
+            let chatMessage = this.game.messages[this.game.messages.length - i - 1];
+            for(let j = 0; j < chatMessage.message.length; j++) {
+                result += getChatString(chatMessage.message[j]);
+            }
+            results.push(result);
+        }
+
+        return reverse ? results.reverse() : results;
+
+        function getChatString(item) {
+            if(Array.isArray(item)) {
+                return item.map(arrItem => getChatString(arrItem)).join('');
+            } else if(item instanceof Object) {
+                if(item.name) {
+                    return item.name;
+                } else if(item.message) {
+                    return getChatString(item.message);
+                }
+            }
+            return item;
+        }
+    }
+
+    /**
+     * Get specified chat message or nothing
+     * @param {Number} idx - the index of the array you want to return, defaults to the latest chat message
+     */
+    getChat(idx = 0) {
+        let messages = this.latestChatMessages(this.game.messages.length, false);
+        return messages.length && messages[idx] ? messages[idx] : '<No Message Found>';
+    }
 }
 
 module.exports = GameFlowWrapper;

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -265,12 +265,12 @@ class GameFlowWrapper {
 
     /**
      * Get an array of the latest chat messages
-     * @param {Number} num - number of messages to retrieve, starting from the latest
+     * @param {Number} numBack - number of messages back from the latest to retrieve
      * @param {Boolean} reverse - reverse the retrieved elements so the array is easily read when printed
      */
-    getChatLogs(num = 1, reverse = true) {
+    getChatLogs(numBack = 1, reverse = true) {
         let results = [];
-        for(let i = 0; i < this.game.messages.length && i < num; i++) {
+        for(let i = 0; i < this.game.messages.length && i < numBack; i++) {
             let result = '';
             let chatMessage = this.game.messages[this.game.messages.length - i - 1];
             for(let j = 0; j < chatMessage.message.length; j++) {
@@ -297,11 +297,11 @@ class GameFlowWrapper {
 
     /**
      * Get specified chat message or nothing
-     * @param {Number} idx - the index of the array you want to return, defaults to the latest chat message
+     * @param {Number} numBack - How far back you want to get a message, defaults to the latest chat message
      */
-    getChatLog(idx = 0) {
-        let messages = this.latestChatMessages(this.game.messages.length, false);
-        return messages.length && messages[idx] ? messages[idx] : '<No Message Found>';
+    getChatLog(numBack = 0) {
+        let messages = this.getChatLogs(numBack + 1, false);
+        return messages.length && messages[numBack] ? messages[numBack] : '<No Message Found>';
     }
 }
 

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -268,7 +268,7 @@ class GameFlowWrapper {
      * @param {Number} num - number of messages to retrieve, starting from the latest
      * @param {Boolean} reverse - reverse the retrieved elements so the array is easily read when printed
      */
-    latestChatMessages(num = 1, reverse = true) {
+    getChatLogs(num = 1, reverse = true) {
         let results = [];
         for(let i = 0; i < this.game.messages.length && i < num; i++) {
             let result = '';
@@ -299,7 +299,7 @@ class GameFlowWrapper {
      * Get specified chat message or nothing
      * @param {Number} idx - the index of the array you want to return, defaults to the latest chat message
      */
-    getChat(idx = 0) {
+    getChatLog(idx = 0) {
         let messages = this.latestChatMessages(this.game.messages.length, false);
         return messages.length && messages[idx] ? messages[idx] : '<No Message Found>';
     }

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -12,8 +12,8 @@ const deckBuilder = new DeckBuilder();
 
 const ProxiedGameFlowWrapperMethods = [
     'eachPlayerInFirstPlayerOrder', 'startGame', 'keepDynasty', 'keepConflict', 'skipSetupPhase', 'selectFirstPlayer',
-    'noMoreActions', 'selectStrongholdProvinces', 'advancePhases', 'getPromptedPlayer', 'nextPhase', 'latestChatMessages',
-    'getChat'
+    'noMoreActions', 'selectStrongholdProvinces', 'advancePhases', 'getPromptedPlayer', 'nextPhase', 'getChatLogs',
+    'getChatLog'
 ];
 
 var customMatchers = {

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -12,7 +12,8 @@ const deckBuilder = new DeckBuilder();
 
 const ProxiedGameFlowWrapperMethods = [
     'eachPlayerInFirstPlayerOrder', 'startGame', 'keepDynasty', 'keepConflict', 'skipSetupPhase', 'selectFirstPlayer',
-    'noMoreActions', 'selectStrongholdProvinces', 'advancePhases', 'getPromptedPlayer', 'nextPhase'
+    'noMoreActions', 'selectStrongholdProvinces', 'advancePhases', 'getPromptedPlayer', 'nextPhase', 'latestChatMessages',
+    'getChat'
 ];
 
 var customMatchers = {


### PR DESCRIPTION
A number of times I've wanted to check the chat logs during a test to see what exactly happened, say in the event of a vague error, so I wrote a couple of helper methods. These will create a readable string from the chat logs.

Thought I'd open a PR and see what people think, this is simpler to write and easier to read than adding a spy if you're only trying to debug.

expected use:
```javascript
// messages = ['first message', 'second message', ['unexpected third message with ', Object({ name: 'Smoke', ... })], 'fourth message']

// Displays latest chat: 'fourth message'
expect(this.getChatLog()).toBe('something') 
// Displays chat log 1 back: 'unexpected third message with Smoke'
expect(this.getChatLog(1)).toBe('something') 
// Displays chat logs 3 back: ['second message', 'unexpected third message with Smoke', 'fourth message']
expect(this.getChatLogs(3)).toBe('something')
```