### PR TITLE
Tetsu Typo

### DIFF
--- a/server/game/cards/03-DotV/ShibaTetsu.js
+++ b/server/game/cards/03-DotV/ShibaTetsu.js
@@ -8,7 +8,7 @@ class ShibaTetsu extends DrawCard {
             when: {
                 onCardPlayed: (event, context) => event.player === context.player && event.card.hasTrait('spell') && this.game.isDuringConflict()
             },
-            effect: 'give him +1{1}/+2{2}',
+            effect: 'give him +1{1}/+1{2}',
             effectArgs: () => ['military', 'political'],
             gameAction: ability.actions.cardLastingEffect({ effect: ability.effects.modifyBothSkills(1) })
         });


### PR DESCRIPTION
Fixed typo in Tetsu's message, was displaying +1[military] / **+2**[Political]