### PR TITLE
Fix fetch script (promo cards)

### DIFF
--- a/server/scripts/fetchdata.js
+++ b/server/scripts/fetchdata.js
@@ -44,8 +44,16 @@ let fetchCards = apiRequest('cards')
         cards.forEach(function(card) {
             var imagePath = path.join(imageDir, card.id + '.jpg');
 
-            if(card.pack_cards.length > 0 && card.pack_cards[0].image_url) {
+            if(card.pack_cards.length == 1 && card.pack_cards[0].image_url) {
                 var imagesrc = card.pack_cards[0].image_url;
+
+                if(imagesrc && !fs.existsSync(imagePath)) {
+                    fetchImage(imagesrc, card.id, imagePath, i++ * 200);
+                }
+            }
+
+	        if(card.pack_cards.length == 2 && card.pack_cards[1].image_url) {
+                var imagesrc = card.pack_cards[1].image_url;
 
                 if(imagesrc && !fs.existsSync(imagePath)) {
                     fetchImage(imagesrc, card.id, imagePath, i++ * 200);

--- a/server/scripts/fetchdata.js
+++ b/server/scripts/fetchdata.js
@@ -43,17 +43,18 @@ let fetchCards = apiRequest('cards')
 
         cards.forEach(function(card) {
             var imagePath = path.join(imageDir, card.id + '.jpg');
+	    let imagesrc;
 
-            if(card.pack_cards.length == 1 && card.pack_cards[0].image_url) {
-                var imagesrc = card.pack_cards[0].image_url;
+            if(card.pack_cards.length === 1 && card.pack_cards[0].image_url) {
+                imagesrc = card.pack_cards[0].image_url;
 
                 if(imagesrc && !fs.existsSync(imagePath)) {
                     fetchImage(imagesrc, card.id, imagePath, i++ * 200);
                 }
             }
 
-	        if(card.pack_cards.length == 2 && card.pack_cards[1].image_url) {
-                var imagesrc = card.pack_cards[1].image_url;
+	    if(card.pack_cards.length === 2 && card.pack_cards[1].image_url) {
+                imagesrc = card.pack_cards[1].image_url;
 
                 if(imagesrc && !fs.existsSync(imagePath)) {
                     fetchImage(imagesrc, card.id, imagePath, i++ * 200);

--- a/server/scripts/fetchdata.js
+++ b/server/scripts/fetchdata.js
@@ -43,7 +43,7 @@ let fetchCards = apiRequest('cards')
 
         cards.forEach(function(card) {
             var imagePath = path.join(imageDir, card.id + '.jpg');
-	    let imagesrc;
+            let imagesrc;
 
             if(card.pack_cards.length === 1 && card.pack_cards[0].image_url) {
                 imagesrc = card.pack_cards[0].image_url;


### PR DESCRIPTION
This quick fix will grab normal card images when there is a promo. The problem was that the API was returning two rows for each card with a promo, listing the promo first. The promo did not have valid image url.

Once there are images associated with promo cards this will need to be reviewed and fixed again