### PR TITLE
Feral Ningyo: additional tests

### DIFF
--- a/test/server/cards/04.2-TL/FeralNingyo.spec.js
+++ b/test/server/cards/04.2-TL/FeralNingyo.spec.js
@@ -7,7 +7,7 @@ describe('Feral Ningyo', function () {
                     player1: {
                         fate: 4,
                         inPlay: ['adept-of-the-waves'],
-                        hand: ['feral-ningyo', 'cloud-the-mind']
+                        hand: ['feral-ningyo', 'cloud-the-mind', 'fine-katana']
                     },
                     player2: {
                         inPlay: ['hida-kisada'],
@@ -51,12 +51,25 @@ describe('Feral Ningyo', function () {
                     });
                 });
 
-                it('should cancel Feral Ningyo being put into play', function () {
+                it('should cancel Feral Ningyo activating it\'s ability the first time', function () {
                     this.player2.clickPrompt('Pass');
                     this.player1.clickCard(this.feral);
                     this.player1.clickPrompt('Put into play');
                     expect(this.feral.location).toBe('hand');
                     expect(this.player2).toHavePrompt('Conflict Action Window');
+                });
+
+                // RRG v1.4: Cards in hidden game areas (e.g. in hand) have no card memory, so Limits do not apply to them.
+                it('should not prevent Feral Ningyo from activating it\'s ability a second time', function () {
+                    this.player2.clickPrompt('Pass');
+                    this.player1.clickCard(this.feral);
+                    this.player1.clickPrompt('Put into play');
+                    expect(this.feral.location).toBe('hand');
+                    expect(this.player2).toHavePrompt('Conflict Action Window');
+                    this.player2.pass();
+                    this.player1.clickCard(this.feral);
+                    this.player1.clickPrompt('Put into play');
+                    expect(this.feral.location).toBe('play area');
                 });
             });
 
@@ -80,6 +93,17 @@ describe('Feral Ningyo', function () {
 
                 it('should return to it the conflict deck at the end of the conflict', function () {
                     this.player1.clickPrompt('Put into play');
+                    this.noMoreActions();
+                    this.player1.clickPrompt('No');
+                    this.player1.clickPrompt('Don\'t resolve');
+                    expect(this.feral.location).toBe('conflict deck');
+                });
+
+                it('should return to it the conflict deck at the end of the conflict even with a card attached', function () {
+                    this.player1.clickPrompt('Put into play');
+                    this.player2.pass();
+                    this.katana = this.player1.playAttachment('fine-katana', this.feral);
+                    expect(this.katana.parent).toBe(this.feral);
                     this.noMoreActions();
                     this.player1.clickPrompt('No');
                     this.player1.clickPrompt('Don\'t resolve');


### PR DESCRIPTION
Someone stated that their Feral Ningyo didn't leave play after the end of a conflict. Only additional detail was it had a attachment. Added a test for that, no dice, though I'd be more surprised if that was the issue anyway.

Also, added a additional test just to verify it's ability can be immediately reused if canceled, [RRG v1.4 "Limit X per [period]"](https://fiveringsdb.com/rules/reference#limit-x-per-period).