### PR TITLE
Ofushikai bugfix

### DIFF
--- a/server/game/cards/04.4-TEaF/Ofushikai.js
+++ b/server/game/cards/04.4-TEaF/Ofushikai.js
@@ -29,7 +29,7 @@ class Ofushukai extends DrawCard {
         if(card.controller !== context.player) {
             return false;
         }
-        return card.isUnique() && card.getPrintedFaction() === 'phoenix' ? super.canAttach(card, context) : false;
+        return card.isUnique() && card.isFaction('phoenix') ? super.canAttach(card, context) : false;
     }
 }
 

--- a/test/server/cards/04.4-TEaF/Ofushikai.spec.js
+++ b/test/server/cards/04.4-TEaF/Ofushikai.spec.js
@@ -6,8 +6,8 @@ describe('Ofushikai', function() {
                     phase: 'conflict',
                     player1: {
                         fate: 3,
-                        inPlay: ['shiba-tsukune', 'asako-tsuki', 'fearsome-mystic'],
-                        hand: ['ofushikai']
+                        inPlay: ['shiba-tsukune', 'asako-tsuki', 'fearsome-mystic', 'yoritomo'],
+                        hand: ['ofushikai', 'seal-of-the-phoenix']
                     },
                     player2: {
                         inPlay: ['crisis-breaker']
@@ -16,13 +16,17 @@ describe('Ofushikai', function() {
                 this.shibaTsukune = this.player1.findCardByName('shiba-tsukune');
                 this.askaoTsuki = this.player1.findCardByName('asako-tsuki');
                 this.fearsomeMysic = this.player1.findCardByName('fearsome-mystic');
+                this.yoritomo = this.player1.findCardByName('yoritomo');
+
+                this.ofushikaiMilitaryBonus = 2;
+                this.ofushikaiPoliticalBonus = 3;
             });
 
             it('should increase the attached characters military an political skills when attached', function() {
                 this.player1.playAttachment('ofushikai', 'shiba-tsukune');
                 expect(this.player2).toHavePrompt('Action Window');
-                expect(this.shibaTsukune.getMilitarySkill()).toBe(this.shibaTsukune.getBaseMilitarySkill() + 2);
-                expect(this.shibaTsukune.getPoliticalSkill()).toBe(this.shibaTsukune.getBasePoliticalSkill() + 3);
+                expect(this.shibaTsukune.getMilitarySkill()).toBe(this.shibaTsukune.getBaseMilitarySkill() + this.ofushikaiMilitaryBonus);
+                expect(this.shibaTsukune.getPoliticalSkill()).toBe(this.shibaTsukune.getBasePoliticalSkill() + this.ofushikaiPoliticalBonus);
             });
 
             it('should grant the ability to a character that is a phoenix champion when attached', function() {
@@ -42,6 +46,36 @@ describe('Ofushikai', function() {
                 this.player1.playAttachment('ofushikai', 'asako-tsuki');
                 expect(this.player2).toHavePrompt('Action Window');
                 expect(this.askaoTsuki.getActions().length).toBe(tsukiActionCount);
+            });
+
+            describe('unique non-phoenix character with the seal of the phoenix attached', function() {
+                beforeEach(function () {
+                    this.player1.playAttachment('seal-of-the-phoenix', 'yoritomo');
+                    this.player2.pass();
+                    this.sealOfThePhoenixMilitaryBonus = 0;
+                    this.sealOfThePhoenixPoliticalBonus = 1;
+                });
+
+                it('should attach', function() {
+                    this.player1.clickCard('ofushikai');
+                    expect(this.player1).toBeAbleToSelect(this.yoritomo);
+                });
+
+                it('should attach and increase the characters skills by +2/+3', function() {
+                    this.player1.clickCard('ofushikai');
+                    this.player1.clickCard(this.yoritomo);
+                    expect(this.yoritomo.getMilitarySkill()).toBe(this.yoritomo.getBaseMilitarySkill() + this.player1.fate + this.sealOfThePhoenixMilitaryBonus + this.ofushikaiMilitaryBonus);
+                    expect(this.yoritomo.getPoliticalSkill()).toBe(this.yoritomo.getBasePoliticalSkill() + this.player1.fate + this.sealOfThePhoenixPoliticalBonus + this.ofushikaiPoliticalBonus);
+                    expect(this.player2).toHavePrompt('Action Window');
+                });
+
+                it('should grant the ability if the character is a champion', function() {
+                    let yoritomoActionCount = this.yoritomo.getActions().length;
+                    this.player1.clickCard('ofushikai');
+                    this.player1.clickCard(this.yoritomo);
+                    expect(this.yoritomo.getActions().length).toBe(yoritomoActionCount + 1);
+                    expect(this.player2).toHavePrompt('Action Window');
+                });
             });
 
             describe('during a conflict', function () {


### PR DESCRIPTION
Fixing bug where attachment could not be attached to non-phoenix
characters that have the seal of the phoenic attached.

resolves #2391 