### PR TITLE
Fix for azunami missing cancel prompt

### DIFF
--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -133,7 +133,11 @@ class SelectCardPrompt extends UiPrompt {
             }
         }
         if((this.selector.optional || this.game.manualMode) && !_.any(buttons, button => button.arg === 'cancel')) {
-            buttons = buttons.concat({ text: 'Cancel Prompt', arg: 'cancel' });
+            let text = 'Cancel Prompt';
+            if(this.selector.optional) {
+                text = typeof this.selector.optional == 'string' ? this.selector.optional : 'Cancel';
+            }
+            buttons = buttons.concat({ text: text, arg: 'cancel' });
         }
         return {
             selectCard: this.properties.selectCard,

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -132,7 +132,7 @@ class SelectCardPrompt extends UiPrompt {
                 buttons = [{ text: 'Done', arg: 'done' }].concat(buttons);
             }
         }
-        if(this.game.manualMode && !_.any(buttons, button => button.arg === 'cancel')) {
+        if((this.selector.optional || this.game.manualMode) && !_.any(buttons, button => button.arg === 'cancel')) {
             buttons = buttons.concat({ text: 'Cancel Prompt', arg: 'cancel' });
         }
         return {

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -135,7 +135,7 @@ class SelectCardPrompt extends UiPrompt {
         if((this.selector.optional || this.game.manualMode) && !_.any(buttons, button => button.arg === 'cancel')) {
             let text = 'Cancel Prompt';
             if(this.selector.optional) {
-                text = typeof this.selector.optional == 'string' ? this.selector.optional : 'Cancel';
+                text = typeof this.selector.optional === 'string' ? this.selector.optional : 'Cancel';
             }
             buttons = buttons.concat({ text: text, arg: 'cancel' });
         }

--- a/test/server/cards/04.4-TEaF/AsakoAzunami.spec.js
+++ b/test/server/cards/04.4-TEaF/AsakoAzunami.spec.js
@@ -75,12 +75,12 @@ describe('Asako Azunami', function() {
                 expect(this.player1).toHavePrompt('Choose a character to bow');
                 expect(this.player1).toBeAbleToSelect(this.seppunGuardsman);
                 expect(this.player1).toBeAbleToSelect('isawa-kaede');
-                this.player1.clickPrompt('Cancel Prompt');
+                this.player1.clickPrompt('Cancel');
                 this.player1.clickCard(this.seppunGuardsman);
                 expect(this.player1).toHavePrompt('Choose a character to ready');
                 expect(this.seppunGuardsman.bowed).toBe(false);
                 expect(this.player1).toBeAbleToSelect(this.shibaTsukune);
-                this.player1.clickPrompt('Cancel Prompt');
+                this.player1.clickPrompt('Cancel');
                 expect(this.player1).toHavePrompt('Action Window');
             });
 

--- a/test/server/cards/04.4-TEaF/AsakoAzunami.spec.js
+++ b/test/server/cards/04.4-TEaF/AsakoAzunami.spec.js
@@ -62,6 +62,28 @@ describe('Asako Azunami', function() {
                 expect(this.player1).toBeAbleToSelect(this.shibaTsukune);
             });
 
+            it('should allow the player to cancel the prompts', function() {
+                this.initiateConflict({
+                    ring: 'water',
+                    attackers: ['asako-azunami'],
+                    defenders: []
+                });
+                this.noMoreActions();
+                // Break Province prompt
+                this.player1.clickPrompt('No');
+                this.player1.clickCard(this.asakoAzunami);
+                expect(this.player1).toHavePrompt('Choose a character to bow');
+                expect(this.player1).toBeAbleToSelect(this.seppunGuardsman);
+                expect(this.player1).toBeAbleToSelect('isawa-kaede');
+                this.player1.clickPrompt('Cancel Prompt');
+                this.player1.clickCard(this.seppunGuardsman);
+                expect(this.player1).toHavePrompt('Choose a character to ready');
+                expect(this.seppunGuardsman.bowed).toBe(false);
+                expect(this.player1).toBeAbleToSelect(this.shibaTsukune);
+                this.player1.clickPrompt('Cancel Prompt');
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+
             it('should bow and ready the selected targets', function() {
                 this.initiateConflict({
                     ring: 'water',


### PR DESCRIPTION
The optional flag wasn't actually adding a button to a card select prompt, hence #2421. Should check for manual mode or optional now.