### PR TITLE
quick fix for nezumi leaving play

### DIFF
--- a/server/game/cannotrestriction.js
+++ b/server/game/cannotrestriction.js
@@ -30,10 +30,10 @@ class CannotRestriction {
     checkCondition(context) {
         if(!this.restriction) {
             return true;
-        } else if(!checkRestrictions[this.restriction]) {
-            return context.source.hasTrait(this.restriction);
         } else if(!context) {
             return false; // throw Error here?
+        } else if(!checkRestrictions[this.restriction]) {
+            return context.source.hasTrait(this.restriction);
         }
         let player = this.player || this.source && this.source.controller;
         return checkRestrictions[this.restriction](context, player, this.source);

--- a/test/server/cards/04.4-TEaF/NezumiInfiltrator.spec.js
+++ b/test/server/cards/04.4-TEaF/NezumiInfiltrator.spec.js
@@ -117,5 +117,31 @@ describe('Nezumi Infiltrator', function() {
                 expect(this.player1).toHavePromptButton('Raise attacked province\'s strength by 1');
             });
         });
+
+        describe('Nezumi Infiltrator leaving play after being dishonored', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        honor: 10,
+                        inPlay: ['nezumi-infiltrator']
+                    },
+                    player2: {
+
+                    }
+                });
+                this.nezumi = this.player1.findCardByName('nezumi-infiltrator');
+                this.nezumi.dishonor();
+                this.nezumi.fate = 0;
+                this.nextPhase();
+            });
+
+            it('should correctly leave play during the fate phase and cause a honor loss', function() {
+                this.p1Honor = this.player1.honor;
+                this.player1.clickPrompt('Done');
+                expect(this.player1.honor).toBe(this.p1Honor - 1);
+                expect(this.nezumi.location).toBe('conflict discard pile');
+            });
+        });
     });
 });


### PR DESCRIPTION
Found the nezumi bug. It starts in `DrawCard.leavesPlay()` on the line `if(this.isDishonored && this.checkRestrictions('affectedByHonor'))`. checkRestrictions isn't getting passed a context and this is causing the crash further down. 

There is a line to check for context but it's happening too late. I moved it back and it's fixed the issue, but I'm a little hesitant to merge it since it seems like a missing context should be an error if anything. Thoughts?

Here's the stack trace.
![stack trace](https://i.imgur.com/XNIEFnv.png)
