### PR TITLE
Fix to allow any # of attachments (and flexbox fixes for hand as well)

### DIFF
--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -472,7 +472,7 @@ class Card extends React.Component {
     render() {
         if(this.props.wrapped) {
             return (
-                <div className={ 'card-wrapper' } style={ Object.assign(this.props.style ? this.props.style : {},this.getWrapperStyle()) }>
+                <div className={ 'card-wrapper' } style={ Object.assign({}, this.props.style ? this.props.style : {},this.getWrapperStyle()) }>
                     { this.getCard() }
                     { this.getAttachments() }
                 </div>);

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -177,16 +177,51 @@ class Card extends React.Component {
         return wrapperClassName;
     }
 
+    getWrapperStyle() {
+        let wrapperStyle = {};
+        let attachmentOffset = 13;
+        switch(this.props.size) {
+            case 'large':
+                attachmentOffset *= 1.4;
+                break;
+            case 'small':
+                attachmentOffset *= 0.8;
+                break;
+            case 'x-large':
+                attachmentOffset *= 2;
+                break;
+        }
+        let attachments = this.props.source === 'play area' ? _.size(this.props.card.attachments) : 0;
+        if(attachments > 0) {
+            wrapperStyle = { marginLeft:(attachments * attachmentOffset) + 'px'};
+        }
+
+        return wrapperStyle;
+    }
+
     getAttachments() {
 
         if(this.props.source !== 'play area') {
             return null;
         }
 
+        let attachmentOffset = 13;
+        let cardLayer = 10;
+        switch(this.props.size) {
+            case 'large':
+                attachmentOffset *= 1.4;
+                break;
+            case 'small':
+                attachmentOffset *= 0.8;
+                break;
+            case 'x-large':
+                attachmentOffset *= 2;
+                break;
+        }
         var index = 1;
         var attachments = _.map(this.props.card.attachments, attachment => {
             var returnedAttachment = (<Card key={ attachment.uuid } source={ this.props.source } card={ attachment }
-                className={ 'attachment attachment-' + index } wrapped={ false }
+                className={ 'attachment' } wrapped={ false } style={ {marginLeft: (-1 * (index * attachmentOffset)) + 'px', zIndex: (cardLayer - index)} }
                 onMouseOver={ this.props.disableMouseOver ? null : this.onMouseOver.bind(this, attachment) }
                 onMouseOut={ this.props.disableMouseOver ? null : this.onMouseOut }
                 onClick={ this.props.onClick }
@@ -326,6 +361,7 @@ class Card extends React.Component {
                 onTouchStart={ ev => this.onTouchStart(ev) }>
                 { this.getCardOrder() }
                 <div className={ cardClass }
+                    style={ this.props.wrapped ? {} : this.props.style }
                     onMouseOver={ this.props.disableMouseOver ? null : this.onMouseOver.bind(this, this.props.card) }
                     onMouseOut={ this.props.disableMouseOver ? null : this.onMouseOut }
                     onClick={ ev => this.onClick(ev, this.props.card) }
@@ -436,7 +472,7 @@ class Card extends React.Component {
     render() {
         if(this.props.wrapped) {
             return (
-                <div className={ 'card-wrapper ' + this.getWrapper() } style={ this.props.style }>
+                <div className={ 'card-wrapper' } style={ Object.assign(this.props.style ? this.props.style : {},this.getWrapperStyle()) }>
                     { this.getCard() }
                     { this.getAttachments() }
                 </div>);

--- a/client/GameComponents/PlayerHand.jsx
+++ b/client/GameComponents/PlayerHand.jsx
@@ -39,25 +39,36 @@ class PlayerHand extends React.Component {
     }
 
     getCards(needsSquish) {
-        let cardIndex = 0;
         let handLength = this.props.cards ? this.props.cards.length : 0;
+        let cardIndex = 1;
         let cardWidth = this.getCardWidth();
-
-        let requiredWidth = handLength * cardWidth;
-        let overflow = requiredWidth - 480;
-        let offset = overflow / (handLength - 1);
+        let attachmentOffset = 13;
+        switch(this.props.size) {
+            case 'large':
+                attachmentOffset *= 1.4;
+                break;
+            case 'small':
+                attachmentOffset *= 0.8;
+                break;
+            case 'x-large':
+                attachmentOffset *= 2;
+                break;
+        }
 
         let hand = _.map(this.props.cards, card => {
-            let left = (cardWidth - offset) * cardIndex++;
-
             let style = {};
+            let className = '';
             if(needsSquish) {
-                style = {
-                    left: left + 'px'
-                };
+                className += ' squish';
+                if(cardIndex++ === handLength) {
+                    className += ' tail';
+                    if(attachmentOffset > (480 / (cardWidth * handLength))) {
+                        className += ' nohide';
+                    }
+                }
             }
 
-            return (<Card key={ card.uuid } card={ card } style={ style } disableMouseOver={ !this.props.isMe } source='hand'
+            return (<Card key={ card.uuid } card={ card } className={ className } style={ style } disableMouseOver={ !this.props.isMe } source='hand'
                 onMouseOver={ this.props.onMouseOver }
                 onMouseOut={ this.props.onMouseOut }
                 onClick={ this.props.onCardClick }

--- a/less/gameboard/hand.less
+++ b/less/gameboard/hand.less
@@ -15,7 +15,7 @@
 
 .hand {
     .card-wrapper {
-        margin: 0 5px 0 0;
+        margin: 0 0 0 0;
     }
 
     &.small {
@@ -36,6 +36,44 @@
     margin: 0px 5px;
 }
 
-.hand.squish .card-wrapper {
-    position: absolute;
+.hand.squish {
+    flex-shrink:1;
+    flex-wrap:nowrap;
+    .card-wrapper {
+        border-radius: 4px 0px 0px 4px;
+        min-width:@attachment-offset;
+        flex-basis:@card-width;
+        &.large {
+            min-width:@attachment-offset-lg;
+            flex-basis:@card-lg-width;
+        }
+
+        &.small {
+            min-width:@attachment-offset-sm;
+            flex-basis:@card-sm-width;
+        }
+        
+        &.x-large {
+            min-width:@attachment-offset-xl;
+            flex-basis:@card-xl-width;
+        }
+        &.tail {
+            overflow:hidden;
+            &.nohide {
+                overflow:visible;
+                border-radius: 4px;
+            }
+        }
+        .card-frame {
+            border-radius: 4px;
+            .card {
+                overflow: visible;
+                border-radius: 4px;
+                .card-image {
+                    border-radius: 4px;
+                }
+            }
+        }
+        
+    }
 }


### PR DESCRIPTION
Updated attachment code to set style values on attachments (and parent wrapper) to enforce the margin offsets, rather than relying on a pregenerated set of classes. Additionally modified hand code to use flexbox and flex-shrink (with a minimum width of attachment-offset for the current card size) rather than manually setting card positions. 