### PR TITLE
Some cards appear in multiple packs, check all for match

### DIFF
--- a/client/DeckEditor.jsx
+++ b/client/DeckEditor.jsx
@@ -178,7 +178,12 @@ class InnerDeckEditor extends React.Component {
 
             let card = _.find(this.props.cards, function(card) {
                 if(pack && card.pack_cards.length) {
-                    return card.name.toLowerCase() === cardName.toLowerCase() && card.pack_cards[0].pack.id === pack.id;
+                    if(card.name.toLowerCase() === cardName.toLowerCase()) {
+                        return _.find(card.pack_cards, function(packCard) {
+                            return packCard.pack.id === pack.id;
+                        });
+                    }
+                    return false;
                 }
                 return card.name.toLowerCase() === cardName.toLowerCase();
             });


### PR DESCRIPTION
Existing code can cause cards that appear in multiple packs (such as Bayushi Liar, which is in Core as well as the 2018 Season One Stronghold Kit) to not match when the pack chosen in the deck editor is not the first in the `pack_cards` array.