### PR TITLE
Hide facedown targeted cards

### DIFF
--- a/client/GameComponents/AbilityTargeting.jsx
+++ b/client/GameComponents/AbilityTargeting.jsx
@@ -4,7 +4,7 @@ import _ from 'underscore';
 
 class AbilityTargeting extends React.Component {
     onMouseOver(event, card) {
-        if(card && this.props.onMouseOver) {
+        if(card && !card.facedown && this.props.onMouseOver) {
             this.props.onMouseOver(card);
         }
     }
@@ -21,8 +21,8 @@ class AbilityTargeting extends React.Component {
                 onMouseOut={ event => this.onMouseOut(event, card) }
                 onMouseOver={ event => this.onMouseOver(event, card) }>
                 <img className='target-card-image vertical'
-                    alt={ card.name }
-                    src={ '/img/cards/' + (!card.facedown ? (card.id + '.jpg') : 'cardback.jpg') } />
+                    alt={ !card.facedown ? card.name : 'facedown ' + card.type }
+                    src={ '/img/cards/' + (!card.facedown ? (card.id + '.jpg') : card.type + 'cardback.jpg') } />
             </div>);
     }
 


### PR DESCRIPTION
Partial fix for #2560 

Not a perfect fix, but hides facedown cards when chosen as a target.  Ideally, the controller should be able to see their own facedown provinces when chosen as a target, but I could not work out a way to get the controller of the target to be passed to the AbilityTargeting.jsx file.