### PR TITLE
Test for iron mine failing to save the character due to a lasting effect

### DIFF
--- a/test/server/cards/02.6-MotE/IronMine.spec.js
+++ b/test/server/cards/02.6-MotE/IronMine.spec.js
@@ -5,38 +5,45 @@ describe('Iron Mine', function() {
                 this.setupTest({
                     phase: 'conflict',
                     player1: {
-                        inPlay: ['matsu-berserker'],
+                        inPlay: ['hida-guardian'],
                         dynastyDiscard: ['iron-mine'],
                         hand: ['assassination']
+                    },
+                    player2: {
+                        inPlay: ['bayushi-aramoro']
                     }
                 });
                 this.ironMine = this.player1.placeCardInProvince('iron-mine', 'province 1');
-                this.matsuBerserker = this.player1.findCardByName('matsu-berserker');
+                this.hidaGuardian = this.player1.findCardByName('hida-guardian');
                 this.assassination = this.player1.findCardByName('assassination');
+
+                this.bayushiAramoro = this.player2.findCardByName('bayushi-aramoro');
 
                 this.noMoreActions();
                 this.initiateConflict({
                     type: 'military',
-                    attackers: [this.matsuBerserker],
-                    defenders: []
+                    attackers: [this.hidaGuardian],
+                    defenders: [this.bayushiAramoro]
                 });
-                this.player2.pass();
-
-                this.player1.clickCard(this.assassination);
-                this.player1.clickCard(this.matsuBerserker);
             });
-
+            
             it('should be able to be used when a character you control is leaving play', function () {
+                this.player2.pass();
+                this.player1.clickCard(this.assassination);
+                this.player1.clickCard(this.hidaGuardian);
                 expect(this.player1).toBeAbleToSelect(this.ironMine);
             });
 
             describe('if it resolves', function () {
                 beforeEach(function () {
+                    this.player2.pass();
+                    this.player1.clickCard(this.assassination);
+                    this.player1.clickCard(this.hidaGuardian);
                     this.player1.clickCard(this.ironMine);
                 });
 
                 it('should prevent the character from leaving play', function () {
-                    expect(this.matsuBerserker.location).toBe('play area');
+                    expect(this.hidaGuardian.location).toBe('play area');
                 });
 
                 it('should sacrifice itself', function () {
@@ -50,6 +57,18 @@ describe('Iron Mine', function() {
 
             });
 
+            describe('if the character still leaves play (due to a lasting effect)', function () {
+                beforeEach(function () {
+                    this.player2.clickCard(this.bayushiAramoro);
+                    this.player2.clickCard(this.hidaGuardian);
+                    this.player1.clickCard(this.ironMine);
+                });
+
+                it('should refill the province', function () {
+                    this.newCard = this.player1.player.getDynastyCardInProvince('province 1');
+                    expect(this.newCard).not.toBeUndefined();
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
Test for #2567 

Iron mine does not refill if there is a lasting effect preventing the save.  This is the error thrown:

```  Message:
    TypeError: context.event.context.refillProvince is not a function
  Stack:
    TypeError: context.event.context.refillProvince is not a function
        at TriggeredAbility.handler (C:\projects\ringteki\server\game\cards\02.6-MotE\IronMine.js:16:39)
        at TriggeredAbility.executeHandler (C:\projects\ringteki\server\game\ThenAbility.js:47:14)
        at AbilityResolver.executeHandler (C:\projects\ringteki\server\game\gamesteps\abilityresolver.js:153:30)
        at InitiateCardAbilityEvent.game.raiseInitiateAbilityEvent [as handler] (C:\projects\ringteki\server\game\gamesteps\abilityresolver.js:135:118)
        at InitiateCardAbilityEvent.executeHandler (C:\projects\ringteki\server\game\Events\Event.js:58:18)
        at _.each.event (C:\projects\ringteki\server\game\Events\EventWindow.js:114:23)
        at Function._.each._.forEach (C:\projects\ringteki\node_modules\underscore\underscore.js:186:9)
        at InitiateAbilityEventWindow.executeHandler (C:\projects\ringteki\server\game\Events\EventWindow.js:110:11)
        at Event.game.raiseEvent [as handler] (C:\projects\ringteki\server\game\Events\InitiateAbilityEventWindow.js:44:19)
        at Event.executeHandler (C:\projects\ringteki\server\game\Events\Event.js:58:18)```