### PR TITLE
Tests - Tainted Lands (+ some fixes)

### DIFF
--- a/server/game/cards/04.2-TL/KuniYori.js
+++ b/server/game/cards/04.2-TL/KuniYori.js
@@ -1,11 +1,11 @@
 const DrawCard = require('../../drawcard.js');
-const { TargetModes } = require('../../Constants');
+const { CardTypes, TargetModes } = require('../../Constants');
 
 class KuniYori extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.game.isDuringConflict('earth'),
-            match: card => card.type === 'creature',
+            match: card => card.getType() === CardTypes.Character,
             effect: ability.effects.modifyBothSkills(1)
         });
 

--- a/server/game/cards/04.2-TL/UpholdingAuthority.js
+++ b/server/game/cards/04.2-TL/UpholdingAuthority.js
@@ -46,8 +46,9 @@ class UpholdingAuthority extends ProvinceCard {
             context.game.addMessage('{0} chooses not to discard anything', context.player);
             return;
         }
-        gameAction.setTarget(cards.splice(0, choice));
-        this.game.addMessage('{0} chooses to discard {1} cop{2} of {3}', context.player, choice, (choice === 1 ? 'y' : 'ies'), cards[0]);
+        let targetCards = cards.splice(0, choice);
+        gameAction.setTarget(targetCards);
+        this.game.addMessage('{0} chooses to discard {1} cop{2} of {3}', context.player, choice, (choice === 1 ? 'y' : 'ies'), targetCards[0]);
     }
 }
 

--- a/server/game/cards/04.2-TL/UpholdingAuthority.js
+++ b/server/game/cards/04.2-TL/UpholdingAuthority.js
@@ -10,7 +10,7 @@ class UpholdingAuthority extends ProvinceCard {
         this.interrupt({
             title: 'Look at opponent\'s hand and discard all copies of a card',
             when: {
-                onBreakProvince: (event, context) => event.card === context.source && context.player.opponent
+                onBreakProvince: (event, context) => event.card === context.source && context.player.opponent && context.player.opponent.hand.size() > 0
             },
             effect: 'look at their opponent\'s hand and choose a card to be discarded',
             gameAction: ability.actions.discardCard(context => ({

--- a/server/game/cards/04.2-TL/UpholdingAuthority.js
+++ b/server/game/cards/04.2-TL/UpholdingAuthority.js
@@ -46,9 +46,8 @@ class UpholdingAuthority extends ProvinceCard {
             context.game.addMessage('{0} chooses not to discard anything', context.player);
             return;
         }
-        let targetCards = cards.splice(0, choice);
-        gameAction.setTarget(targetCards);
-        this.game.addMessage('{0} chooses to discard {1} cop{2} of {3}', context.player, choice, (choice === 1 ? 'y' : 'ies'), targetCards[0]);
+        gameAction.setTarget(cards.slice(0, choice));
+        this.game.addMessage('{0} chooses to discard {1} cop{2} of {3}', context.player, choice, (choice === 1 ? 'y' : 'ies'), cards[0]);
     }
 }
 

--- a/test/server/cards/04.2-TL/AsahinaTakako.spec.js
+++ b/test/server/cards/04.2-TL/AsahinaTakako.spec.js
@@ -12,6 +12,7 @@ describe('Asahina Takako', function() {
                 this.dojiChallenger = this.player1.placeCardInProvince('doji-challenger', 'province 1');
                 this.dojiChallenger.facedown = true;
                 this.dojiWhisperer = this.player1.placeCardInProvince('doji-whisperer', 'province 2');
+                this.dojiWhisperer.facedown = true;
             });
 
             it('should allow facedown cards to be seen', function() {
@@ -29,7 +30,25 @@ describe('Asahina Takako', function() {
                 expect(this.player2).toHavePrompt('Action Window');
             });
 
-            it('should allow switching two dynasty cards', function() {
+            it('should allow switching two dynasty cards (facedown)', function() {
+                expect(this.dojiChallenger.facedown).toBe(true);
+                expect(this.dojiWhisperer.facedown).toBe(true);
+                this.player1.clickCard('asahina-takako');
+                expect(this.player1).toHavePrompt('Choose a card');
+                this.player1.clickCard(this.dojiChallenger);
+                expect(this.player1).toHavePrompt('Select an action:');
+                this.player1.clickPrompt('Switch with another card');
+                this.player1.clickCard(this.dojiWhisperer);
+                expect(this.dojiChallenger.location).toBe('province 2');
+                expect(this.dojiWhisperer.location).toBe('province 1');
+                expect(this.player2).toHavePrompt('Action Window');
+            });
+
+            it('should allow switching two dynasty cards (faceup)', function() {
+                this.dojiChallenger.facedown = false;
+                this.dojiWhisperer.facedown = false;
+                expect(this.dojiChallenger.facedown).toBe(false);
+                expect(this.dojiWhisperer.facedown).toBe(false);
                 this.player1.clickCard('asahina-takako');
                 expect(this.player1).toHavePrompt('Choose a card');
                 this.player1.clickCard(this.dojiChallenger);

--- a/test/server/cards/04.2-TL/KuniYori.spec.js
+++ b/test/server/cards/04.2-TL/KuniYori.spec.js
@@ -1,29 +1,105 @@
 describe('Kuni Yori', function() {
     integration(function() {
-        describe('Kuni Yori\'s ability', function() {
+        describe('', function() {
             beforeEach(function() {
                 this.setupTest({
                     phase: 'conflict',
                     player1: {
-                        inPlay: ['kuni-yori']
+                        inPlay: ['kuni-yori', 'borderlands-defender','vanguard-warrior']
                     },
                     player2: {
-                        inPlay: []
+                        inPlay: ['doji-whisperer'],
+                        hand: ['banzai', 'banzai', 'banzai']
                     }
                 });
-                this.noMoreActions();
+                this.kuniYori = this.player1.findCardByName('kuni-yori');
+                this.borderlandsDefender = this.player1.findCardByName('borderlands-defender');
+                this.vanguardWarrior = this.player1.findCardByName('vanguard-warrior');
+                this.dojiWhisperer = this.player2.findCardByName('doji-whisperer');
             });
 
-            it('should trigger under XYZ circumstances', function() {
+            describe('Kuni Yori\'s constant ability', function() {
+                it('should have no effect outside of earth conflicts', function() {
+                    expect(this.kuniYori.getMilitarySkill()).toBe(4);
+                    expect(this.kuniYori.getPoliticalSkill()).toBe(4);
+                    expect(this.borderlandsDefender.getMilitarySkill()).toBe(3);
+                    expect(this.borderlandsDefender.getPoliticalSkill()).toBe(3);
+                    expect(this.vanguardWarrior.getMilitarySkill()).toBe(2);
+                    expect(this.vanguardWarrior.getPoliticalSkill()).toBe(1);
+                    expect(this.dojiWhisperer.getMilitarySkill()).toBe(0);
+                    expect(this.dojiWhisperer.getPoliticalSkill()).toBe(3);
+                    this.noMoreActions();
+                    this.initiateConflict({
+                        attackers: [this.kuniYori, this.borderlandsDefender],
+                        defenders: [],
+                        ring: 'air'
+                    });
+                    expect(this.kuniYori.getMilitarySkill()).toBe(4);
+                    expect(this.kuniYori.getPoliticalSkill()).toBe(4);
+                    expect(this.borderlandsDefender.getMilitarySkill()).toBe(3);
+                    expect(this.borderlandsDefender.getPoliticalSkill()).toBe(3);
+                    expect(this.vanguardWarrior.getMilitarySkill()).toBe(2);
+                    expect(this.vanguardWarrior.getPoliticalSkill()).toBe(1);
+                    expect(this.dojiWhisperer.getMilitarySkill()).toBe(0);
+                    expect(this.dojiWhisperer.getPoliticalSkill()).toBe(3);
+                });
 
+                it('should give +1/+1 to all characters you control', function() {
+                    this.noMoreActions();
+                    this.initiateConflict({
+                        attackers: [this.kuniYori, this.borderlandsDefender],
+                        defenders: [],
+                        ring: 'earth'
+                    });
+                    expect(this.kuniYori.getMilitarySkill()).toBe(5);
+                    expect(this.kuniYori.getPoliticalSkill()).toBe(5);
+                    expect(this.borderlandsDefender.getMilitarySkill()).toBe(4);
+                    expect(this.borderlandsDefender.getPoliticalSkill()).toBe(4);
+                    expect(this.vanguardWarrior.getMilitarySkill()).toBe(3);
+                    expect(this.vanguardWarrior.getPoliticalSkill()).toBe(2);
+                    expect(this.dojiWhisperer.getMilitarySkill()).toBe(0);
+                    expect(this.dojiWhisperer.getPoliticalSkill()).toBe(3);
+                });
             });
 
-            it('should not trigger under ABC circumstances', function() {
+            describe('Kuni Yori\'s triggered ability', function() {
+                it('should not trigger outside of a conflict', function() {
+                    expect(this.player1).toHavePrompt('Action Window');
+                    this.player1.clickCard(this.kuniYori);
+                    expect(this.player1).toHavePrompt('Action Window');
+                });
 
-            });
+                describe('during a conflict', function() {
+                    beforeEach(function() {
+                        this.noMoreActions();
+                        this.initiateConflict({
+                            attackers: [this.kuniYori, this.borderlandsDefender],
+                            defenders: []
+                        });
+                        this.player2.pass();
+                    });
 
-            it('should have DEF effect on GHI', function() {
+                    it('should prompt to choose a player', function() {
+                        this.player1.clickCard(this.kuniYori);
+                        expect(this.player1).toHavePrompt('Select a player to discard a random card from his/her hand');
+                        expect(this.player1).toHavePromptButton('Me');
+                        expect(this.player1).toHavePromptButton('My Opponent');
+                    });
 
+                    it('should cost 1 honor', function() {
+                        let honor = this.player1.player.honor;
+                        this.player1.clickCard(this.kuniYori);
+                        this.player1.clickPrompt('My Opponent');
+                        expect(this.player1.player.honor).toBe(honor - 1);
+                    });
+
+                    it('should discard 1 card at random from the chosen player\'s hand', function() {
+                        let handSize = this.player2.player.hand.size();
+                        this.player1.clickCard(this.kuniYori);
+                        this.player1.clickPrompt('My Opponent');
+                        expect(this.player2.player.hand.size()).toBe(handSize - 1);
+                    });
+                });
             });
         });
     });

--- a/test/server/cards/04.2-TL/PressOfBattle.spec.js
+++ b/test/server/cards/04.2-TL/PressOfBattle.spec.js
@@ -5,25 +5,79 @@ describe('Press of Battle', function() {
                 this.setupTest({
                     phase: 'conflict',
                     player1: {
-                        inPlay: []
+                        inPlay: ['border-rider', 'aggressive-moto', 'giver-of-gifts'],
+                        hand: ['press-of-battle']
                     },
                     player2: {
-                        inPlay: []
+                        inPlay: ['doji-whisperer', 'doji-hotaru', 'cautious-scout']
                     }
                 });
+                this.borderRider = this.player1.findCardByName('border-rider');
+                this.aggresiveMoto = this.player1.findCardByName('aggressive-moto');
+                this.giverOfGifts = this.player1.findCardByName('giver-of-gifts');
+                this.dojiWhisperer = this.player2.findCardByName('doji-whisperer');
+                this.dojiHotaru = this.player2.findCardByName('doji-hotaru');
+                this.cautiousScout = this.player2.findCardByName('cautious-scout');
+
+                this.pressOfBattle = this.player1.findCardByName('press-of-battle');
+            });
+
+            it('should not trigger outside of a military conflict', function() {
+                expect(this.player1).toHavePrompt('Action Window');
+                this.player1.clickCard(this.pressOfBattle);
+                expect(this.player1).toHavePrompt('Action Window');
                 this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.borderRider, this.aggresiveMoto],
+                    defenders: [this.dojiWhisperer],
+                    type: 'political'
+                });
+                this.player2.pass();
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+                this.player1.clickCard(this.pressOfBattle);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
             });
 
-            it('should trigger under XYZ circumstances', function() {
-
+            it('should not trigger if you have the same or fewer characters', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.borderRider],
+                    defenders: [this.dojiWhisperer]
+                });
+                this.player2.pass();
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+                this.player1.clickCard(this.pressOfBattle);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
             });
 
-            it('should not trigger under ABC circumstances', function() {
-
+            it('should prompt to choose a non-unique participating character', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.borderRider, this.aggresiveMoto, this.giverOfGifts],
+                    defenders: [this.dojiWhisperer, this.dojiHotaru]
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.pressOfBattle);
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).toBeAbleToSelect(this.borderRider);
+                expect(this.player1).toBeAbleToSelect(this.aggresiveMoto);
+                expect(this.player1).toBeAbleToSelect(this.giverOfGifts);
+                expect(this.player1).toBeAbleToSelect(this.dojiWhisperer);
+                expect(this.player1).not.toBeAbleToSelect(this.dojiHotaru);
+                expect(this.player1).not.toBeAbleToSelect(this.cautiousScout);
             });
 
-            it('should have DEF effect on GHI', function() {
-
+            it('should bow the chosen character', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.borderRider, this.aggresiveMoto, this.giverOfGifts],
+                    defenders: [this.dojiWhisperer, this.dojiHotaru]
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.pressOfBattle);
+                expect(this.dojiWhisperer.bowed).toBe(false);
+                this.player1.clickCard(this.dojiWhisperer);
+                expect(this.dojiWhisperer.bowed).toBe(true);
             });
         });
     });

--- a/test/server/cards/04.2-TL/Sabotage.spec.js
+++ b/test/server/cards/04.2-TL/Sabotage.spec.js
@@ -5,24 +5,65 @@ describe('Sabotage', function() {
                 this.setupTest({
                     phase: 'conflict',
                     player1: {
-                        inPlay: []
+                        inPlay: ['borderlands-defender'],
+                        hand: ['sabotage']
                     },
                     player2: {
-                        inPlay: []
+                        inPlay: [],
+                        dynastyDiscard: ['favorable-ground']
                     }
                 });
+                this.borderlandsDefender = this.player1.findCardByName('borderlands-defender');
+                this.sabotage = this.player1.findCardByName('sabotage');
+                this.favorableGround = this.player2.placeCardInProvince('favorable-ground', 'province 1');
+            });
+
+            it('should not trigger outside of a military conflict', function() {
+                expect(this.player1).toHavePrompt('Action Window');
+                this.player1.clickCard(this.sabotage);
+                expect(this.player1).toHavePrompt('Action Window');
                 this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.borderlandsDefender],
+                    defenders: [],
+                    type: 'political'
+                });
+                this.player2.pass();
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+                this.player1.clickCard(this.sabotage);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
             });
 
-            it('should trigger under XYZ circumstances', function() {
-
+            it('should prompt to choose a card in your opponent\'s provinces', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.borderlandsDefender],
+                    defenders: []
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.sabotage);
+                expect(this.player1).toHavePrompt('Choose a card');
+                expect(this.player1).toBeAbleToSelect(this.favorableGround);
+                expect(this.player1).toBeAbleToSelect(this.player2.provinces['province 2'].dynastyCards[0]);
+                expect(this.player1).toBeAbleToSelect(this.player2.provinces['province 3'].dynastyCards[0]);
+                expect(this.player1).toBeAbleToSelect(this.player2.provinces['province 4'].dynastyCards[0]);
+                expect(this.player1).not.toBeAbleToSelect(this.player1.provinces['province 1'].dynastyCards[0]);
+                expect(this.player1).not.toBeAbleToSelect(this.player1.provinces['province 2'].dynastyCards[0]);
+                expect(this.player1).not.toBeAbleToSelect(this.player1.provinces['province 3'].dynastyCards[0]);
+                expect(this.player1).not.toBeAbleToSelect(this.player1.provinces['province 4'].dynastyCards[0]);
             });
 
-            it('should not trigger under ABC circumstances', function() {
-
-            });
-
-            it('should have DEF effect on GHI', function() {
+            it('should discard the chosen card', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.borderlandsDefender],
+                    defenders: []
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.sabotage);
+                expect(this.favorableGround.location).toBe('province 1');
+                this.player1.clickCard(this.favorableGround);
+                expect(this.favorableGround.location).toBe('dynasty discard pile');
 
             });
         });

--- a/test/server/cards/04.2-TL/TeachingsOfTheElements.spec.js
+++ b/test/server/cards/04.2-TL/TeachingsOfTheElements.spec.js
@@ -5,25 +5,44 @@ describe('Teachings of the Elements', function() {
                 this.setupTest({
                     phase: 'conflict',
                     player1: {
-                        inPlay: []
+                        inPlay: ['doji-whisperer', 'doji-hotaru', 'savvy-politician']
                     },
                     player2: {
-                        inPlay: []
+                        provinces: ['teachings-of-the-elements'],
+                        inPlay: ['radiant-orator']
                     }
                 });
+                this.dojiWhisperer = this.player1.findCardByName('doji-whisperer');
+                this.dojiHotaru = this.player1.findCardByName('doji-hotaru');
+                this.savvyPolitician = this.player1.findCardByName('savvy-politician');
+                this.teachingsOfTheElements = this.player2.findCardByName('teachings-of-the-elements');
+                this.radiantOrator = this.player2.findCardByName('radiant-orator');
                 this.noMoreActions();
             });
 
-            it('should trigger under XYZ circumstances', function() {
-
-            });
-
-            it('should not trigger under ABC circumstances', function() {
-
-            });
-
-            it('should have DEF effect on GHI', function() {
-
+            it('should have +1 strength for each claimed ring', function() {
+                expect(this.teachingsOfTheElements.getStrength()).toBe(5);
+                this.initiateConflict({
+                    attackers: [this.dojiWhisperer],
+                    defenders: [],
+                    ring: 'air',
+                    type: 'political',
+                    jumpTo: 'afterConflict'
+                });
+                this.player1.clickPrompt('Take 1 honor from opponent');
+                expect(this.game.rings.air.claimed).toBe(true);
+                expect(this.teachingsOfTheElements.getStrength()).toBe(6);
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.radiantOrator],
+                    defenders: [],
+                    ring: 'earth',
+                    type: 'military',
+                    jumpTo: 'afterConflict'
+                });
+                this.player2.clickPrompt('Draw a card and opponent discards');
+                expect(this.game.rings.earth.claimed).toBe(true);
+                expect(this.teachingsOfTheElements.getStrength()).toBe(7);
             });
         });
     });

--- a/test/server/cards/04.2-TL/UpholdingAuthority.spec.js
+++ b/test/server/cards/04.2-TL/UpholdingAuthority.spec.js
@@ -119,5 +119,33 @@ describe('Upholding Authority', function() {
                 expect(this.chat).toHaveBeenCalledWith('{0} chooses to discard {1} cop{2} of {3}', this.player2.player, 3, 'ies', this.banzai1);
             });
         });
+
+        describe('Upholding Authority\'s ability when the opponent has zero cards in hand', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['matsu-berserker'],
+                        hand: []
+                    },
+                    player2: {
+                        provinces: ['upholding-authority']
+                    }
+                });
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: ['matsu-berserker'],
+                    defenders: [],
+                    jumpTo: 'afterConflict'
+                });
+            });
+
+            it('should not be able to be triggered', function() {
+                expect(this.player1.player.hand.size()).toBe(0);
+                expect(this.player2).not.toHavePrompt('Triggered Abilities');
+                this.upholdingAuthority = this.player2.clickCard('upholding-authority');
+            });
+        });
+
     });
 });

--- a/test/server/cards/04.2-TL/UpholdingAuthority.spec.js
+++ b/test/server/cards/04.2-TL/UpholdingAuthority.spec.js
@@ -6,7 +6,7 @@ describe('Upholding Authority', function() {
                     phase: 'conflict',
                     player1: {
                         inPlay: ['matsu-berserker'],
-                        hand: ['banzai', 'banzai', 'charge', 'court-games']
+                        hand: ['banzai', 'banzai', 'banzai', 'charge', 'court-games']
                     },
                     player2: {
                         provinces: ['upholding-authority']
@@ -51,32 +51,42 @@ describe('Upholding Authority', function() {
 
             it('should ask the player how many cards to discard if the player picks a card with multiple copies', function() {
                 this.upholdingAuthority = this.player2.clickCard('upholding-authority');
-                this.banzai1 = this.player1.findCardByName('banzai');
-                this.player2.clickPrompt('Banzai! (2)');
+                this.player2.clickPrompt('Banzai! (3)');
                 expect(this.player2).toHavePrompt('Choose how many cards to discard');
                 expect(this.player2.currentButtons).toContain('0');
                 expect(this.player2.currentButtons).toContain('1');
                 expect(this.player2.currentButtons).toContain('2');
+                expect(this.player2.currentButtons).toContain('3');
             });
 
             it('should discard the correct number of cards if the player picks a card with multiple copies (0 chosen)', function() {
                 this.upholdingAuthority = this.player2.clickCard('upholding-authority');
-                this.banzai = this.player1.findCardByName('banzai');
-                this.player2.clickPrompt('Banzai! (2)');
+                this.banzaiCards = this.player1.filterCardsByName('banzai');
+                this.banzai1 = this.banzaiCards[0];
+                this.banzai2 = this.banzaiCards[1];
+                this.banzai3 = this.banzaiCards[2];
+                this.player2.clickPrompt('Banzai! (3)');
                 this.player2.clickPrompt('0');
-                expect(this.banzai.location).toBe('hand');
+                expect(this.banzai1.location).toBe('hand');
+                expect(this.banzai2.location).toBe('hand');
+                expect(this.banzai3.location).toBe('hand');
                 expect(this.player1).toHavePrompt('Break Upholding Authority');
                 expect(this.chat).toHaveBeenCalledWith('{0} chooses not to discard anything', this.player2.player);
             });
 
             it('should discard the correct number of cards if the player picks a card with multiple copies (1 chosen)', function() {
                 this.upholdingAuthority = this.player2.clickCard('upholding-authority');
-                this.banzai = this.player1.findCardByName('banzai');
-                this.player2.clickPrompt('Banzai! (2)');
+                this.banzaiCards = this.player1.filterCardsByName('banzai');
+                this.banzai1 = this.banzaiCards[0];
+                this.banzai2 = this.banzaiCards[1];
+                this.banzai3 = this.banzaiCards[2];
+                this.player2.clickPrompt('Banzai! (3)');
                 this.player2.clickPrompt('1');
-                expect(this.banzai.location).toBe('conflict discard pile');
+                expect(this.banzai1.location).toBe('conflict discard pile');
+                expect(this.banzai2.location).toBe('hand');
+                expect(this.banzai3.location).toBe('hand');
                 expect(this.player1).toHavePrompt('Break Upholding Authority');
-                expect(this.chat).toHaveBeenCalledWith('{0} chooses to discard {1} cop{2} of {3}', this.player2.player, 1, 'y', this.banzai);
+                expect(this.chat).toHaveBeenCalledWith('{0} chooses to discard {1} cop{2} of {3}', this.player2.player, 1, 'y', this.banzai1);
             });
 
             it('should discard the correct number of cards if the player picks a card with multiple copies (2 chosen)', function() {
@@ -84,12 +94,29 @@ describe('Upholding Authority', function() {
                 this.banzaiCards = this.player1.filterCardsByName('banzai');
                 this.banzai1 = this.banzaiCards[0];
                 this.banzai2 = this.banzaiCards[1];
-                this.player2.clickPrompt('Banzai! (2)');
+                this.banzai3 = this.banzaiCards[2];
+                this.player2.clickPrompt('Banzai! (3)');
                 this.player2.clickPrompt('2');
                 expect(this.banzai1.location).toBe('conflict discard pile');
                 expect(this.banzai2.location).toBe('conflict discard pile');
+                expect(this.banzai3.location).toBe('hand');
                 expect(this.player1).toHavePrompt('Break Upholding Authority');
                 expect(this.chat).toHaveBeenCalledWith('{0} chooses to discard {1} cop{2} of {3}', this.player2.player, 2, 'ies', this.banzai1);
+            });
+
+            it('should discard the correct number of cards if the player picks a card with multiple copies (3 chosen)', function() {
+                this.upholdingAuthority = this.player2.clickCard('upholding-authority');
+                this.banzaiCards = this.player1.filterCardsByName('banzai');
+                this.banzai1 = this.banzaiCards[0];
+                this.banzai2 = this.banzaiCards[1];
+                this.banzai3 = this.banzaiCards[2];
+                this.player2.clickPrompt('Banzai! (3)');
+                this.player2.clickPrompt('3');
+                expect(this.banzai1.location).toBe('conflict discard pile');
+                expect(this.banzai2.location).toBe('conflict discard pile');
+                expect(this.banzai3.location).toBe('conflict discard pile');
+                expect(this.player1).toHavePrompt('Break Upholding Authority');
+                expect(this.chat).toHaveBeenCalledWith('{0} chooses to discard {1} cop{2} of {3}', this.player2.player, 3, 'ies', this.banzai1);
             });
         });
     });

--- a/test/server/cards/04.2-TL/UpholdingAuthority.spec.js
+++ b/test/server/cards/04.2-TL/UpholdingAuthority.spec.js
@@ -18,6 +18,7 @@ describe('Upholding Authority', function() {
                     defenders: [],
                     jumpTo: 'afterConflict'
                 });
+                this.chat = spyOn(this.game, 'addMessage');
             });
 
             it('should trigger when it is broken', function() {
@@ -58,13 +59,37 @@ describe('Upholding Authority', function() {
                 expect(this.player2.currentButtons).toContain('2');
             });
 
-            it('should discard the correct number of cards if the player picks a card with multiple copies', function() {
+            it('should discard the correct number of cards if the player picks a card with multiple copies (0 chosen)', function() {
+                this.upholdingAuthority = this.player2.clickCard('upholding-authority');
+                this.banzai = this.player1.findCardByName('banzai');
+                this.player2.clickPrompt('Banzai! (2)');
+                this.player2.clickPrompt('0');
+                expect(this.banzai.location).toBe('hand');
+                expect(this.player1).toHavePrompt('Break Upholding Authority');
+                expect(this.chat).toHaveBeenCalledWith('{0} chooses not to discard anything', this.player2.player);
+            });
+
+            it('should discard the correct number of cards if the player picks a card with multiple copies (1 chosen)', function() {
                 this.upholdingAuthority = this.player2.clickCard('upholding-authority');
                 this.banzai = this.player1.findCardByName('banzai');
                 this.player2.clickPrompt('Banzai! (2)');
                 this.player2.clickPrompt('1');
                 expect(this.banzai.location).toBe('conflict discard pile');
                 expect(this.player1).toHavePrompt('Break Upholding Authority');
+                expect(this.chat).toHaveBeenCalledWith('{0} chooses to discard {1} cop{2} of {3}', this.player2.player, 1, 'y', this.banzai);
+            });
+
+            it('should discard the correct number of cards if the player picks a card with multiple copies (2 chosen)', function() {
+                this.upholdingAuthority = this.player2.clickCard('upholding-authority');
+                this.banzaiCards = this.player1.filterCardsByName('banzai');
+                this.banzai1 = this.banzaiCards[0];
+                this.banzai2 = this.banzaiCards[1];
+                this.player2.clickPrompt('Banzai! (2)');
+                this.player2.clickPrompt('2');
+                expect(this.banzai1.location).toBe('conflict discard pile');
+                expect(this.banzai2.location).toBe('conflict discard pile');
+                expect(this.player1).toHavePrompt('Break Upholding Authority');
+                expect(this.chat).toHaveBeenCalledWith('{0} chooses to discard {1} cop{2} of {3}', this.player2.player, 2, 'ies', this.banzai1);
             });
         });
     });


### PR DESCRIPTION
Includes a fix for Kuni Yori constant ability and a fix for Upholding Authority's message when discarding more than 1 card.

Completes 100% coverage for Tainted Lands.