### PR TITLE
CotE - Isawa Ujina

### DIFF
--- a/server/game/GameActions/CardGameAction.ts
+++ b/server/game/GameActions/CardGameAction.ts
@@ -35,7 +35,7 @@ export class CardGameAction extends GameAction {
     updateLeavesPlayEvent(event, card: BaseCard, context: AbilityContext, additionalProperties): void {
         let properties = this.getProperties(context, additionalProperties) as any;
         super.updateEvent(event, card, context, additionalProperties);
-        event.destination = properties.destination || card.isDynasty ? Locations.DynastyDiscardPile : Locations.ConflictDiscardPile;
+        event.destination = properties.destination || (card.isDynasty ? Locations.DynastyDiscardPile : Locations.ConflictDiscardPile);
         event.preResolutionEffect = () => {
             event.cardStateWhenLeftPlay = event.card.createSnapshot();
             if(event.card.isAncestral() && event.isContingent) {

--- a/server/game/GameActions/GameActions.ts
+++ b/server/game/GameActions/GameActions.ts
@@ -39,6 +39,7 @@ import { RandomDiscardAction, RandomDiscardProperties } from './RandomDiscardAct
 import { ReadyAction, ReadyProperties } from './ReadyAction';
 import { RefillFaceupAction, RefillFaceupProperties } from './RefillFaceupAction';
 import { RemoveFateAction, RemoveFateProperties } from './RemoveFateAction';
+import { RemoveFromGameAction, RemoveFromGameProperties } from './RemoveFromGameAction';
 import { ResolveAbilityAction, ResolveAbilityProperties } from './ResolveAbilityAction';
 import { ResolveConflictRingAction, ResolveConflictRingProperties } from './ResolveConflictRingAction';
 import { ResolveElementAction, ResolveElementProperties } from './ResolveElementAction';
@@ -82,6 +83,7 @@ const GameActions = {
     putIntoPlay: (propertyFactory: PutIntoPlayProperties | ((context: TriggeredAbilityContext) => PutIntoPlayProperties) = {}) => new PutIntoPlayAction(propertyFactory, false), // fate = 0, status = ordinary
     ready: (propertyFactory: ReadyProperties | ((context: TriggeredAbilityContext) => ReadyProperties) = {}) => new ReadyAction(propertyFactory),
     removeFate: (propertyFactory: RemoveFateProperties | ((context: TriggeredAbilityContext) => RemoveFateProperties) = {}) => new RemoveFateAction(propertyFactory), // amount = 1, recipient
+    removeFromGame: (propertyFactory: RemoveFromGameProperties | ((context: TriggeredAbilityContext) => RemoveFromGameProperties) = {}) => new RemoveFromGameAction(propertyFactory),
     resolveAbility: (propertyFactory: ResolveAbilityProperties | ((context: TriggeredAbilityContext) => ResolveAbilityProperties)) => new ResolveAbilityAction(propertyFactory), // ability
     returnToDeck: (propertyFactory: ReturnToDeckProperties | ((context: TriggeredAbilityContext) => ReturnToDeckProperties) = {}) => new ReturnToDeckAction(propertyFactory), // bottom = false
     returnToHand: (propertyFactory: ReturnToHandProperties | ((context: TriggeredAbilityContext) => ReturnToHandProperties) = {}) => new ReturnToHandAction(propertyFactory),

--- a/server/game/GameActions/RemoveFromGameAction.ts
+++ b/server/game/GameActions/RemoveFromGameAction.ts
@@ -1,0 +1,41 @@
+import AbilityContext = require("../AbilityContext");
+import BaseCard = require('../basecard');
+
+import { CardGameAction, CardActionProperties } from './CardGameAction';
+import { Locations, CardTypes, EventNames } from '../Constants';
+
+export interface RemoveFromGameProperties extends CardActionProperties {
+}
+
+export class RemoveFromGameAction extends CardGameAction {
+    name = 'removeFromGame';
+    eventName = EventNames.OnCardLeavesPlay;
+    cost = 'removing {0} from the game';
+    targetType = [CardTypes.Character, CardTypes.Attachment, CardTypes.Holding];
+
+    getEffectMessage(context: AbilityContext): [string, any[]] {
+        let properties = this.getProperties(context);
+        return['remove {0} from the game', [properties.target]];
+    }
+
+    canAffect(card: BaseCard, context: AbilityContext): boolean {
+        if(card.type === CardTypes.Holding) {
+            if(!card.location.includes('province')) {
+                return false;
+            }
+        } else if(card.location !== Locations.PlayArea) {
+            return false;
+        }
+        return super.canAffect(card, context);
+    }
+
+    updateEvent(event, card: BaseCard, context: AbilityContext, additionalProperties): void {
+        additionalProperties.destination = Locations.RemovedFromGame;
+        this.updateLeavesPlayEvent(event, card, context, additionalProperties);
+    }
+
+    eventHandler(event): void {
+        event.destination = Locations.RemovedFromGame;
+        this.leavesPlayEventHandler(event);
+    }
+}

--- a/server/game/GameActions/RemoveFromGameAction.ts
+++ b/server/game/GameActions/RemoveFromGameAction.ts
@@ -12,11 +12,7 @@ export class RemoveFromGameAction extends CardGameAction {
     eventName = EventNames.OnCardLeavesPlay;
     cost = 'removing {0} from the game';
     targetType = [CardTypes.Character, CardTypes.Attachment, CardTypes.Holding];
-
-    getEffectMessage(context: AbilityContext): [string, any[]] {
-        let properties = this.getProperties(context);
-        return['remove {0} from the game', [properties.target]];
-    }
+    effect = 'remove {0} from the game'
 
     canAffect(card: BaseCard, context: AbilityContext): boolean {
         if(card.type === CardTypes.Holding) {
@@ -35,7 +31,6 @@ export class RemoveFromGameAction extends CardGameAction {
     }
 
     eventHandler(event): void {
-        event.destination = Locations.RemovedFromGame;
         this.leavesPlayEventHandler(event);
     }
 }

--- a/server/game/cards/06-CotE/IsawaUjina.js
+++ b/server/game/cards/06-CotE/IsawaUjina.js
@@ -1,0 +1,25 @@
+const DrawCard = require('../../drawcard.js');
+const { CardTypes } = require('../../Constants');
+const AbilityDsl = require('../../abilitydsl.js');
+
+class IsawaUjina extends DrawCard {
+    setupCardAbilities() {
+        this.forcedReaction({
+            title: 'Remove a character from the game',
+            when: {
+                onClaimRing: (event) => event.conflict && event.conflict.ring.hasElement('void')
+            },
+            target: {
+                cardType: CardTypes.Character,
+                cardCondition: card => card.fate === 0,
+                gameAction: AbilityDsl.actions.removeFromGame()
+            },
+            limit: AbilityDsl.limit.unlimitedPerConflict()
+        });
+    }
+
+}
+
+IsawaUjina.id = 'isawa-ujina';
+
+module.exports = IsawaUjina;

--- a/test/server/cards/06-CotE/IsawaUjina.spec.js
+++ b/test/server/cards/06-CotE/IsawaUjina.spec.js
@@ -5,7 +5,7 @@ describe('Isawa Ujina', function() {
                 this.setupTest({
                     phase: 'conflict',
                     player1: {
-                        inPlay: ['isawa-ujina', 'adept-of-the-waves', 'fushicho'],
+                        inPlay: ['isawa-ujina', 'adept-of-the-waves', 'fushicho', 'isawa-kaede'],
                         hand: ['know-the-world', 'know-the-world']
                     },
                     player2: {
@@ -18,6 +18,7 @@ describe('Isawa Ujina', function() {
                 let knowTheWorlds = this.player1.filterCardsByName('know-the-world');
                 this.knowTheWorld1 = knowTheWorlds[0];
                 this.knowTheWorld2 = knowTheWorlds[1];
+                this.isawaKaede = this.player1.findCardByName('isawa-kaede');
 
                 this.callowDelegate = this.player2.findCardByName('callow-delegate');
                 this.dojiChallenger = this.player2.findCardByName('doji-challenger');
@@ -52,6 +53,22 @@ describe('Isawa Ujina', function() {
                 expect(this.player1).toHavePrompt('Isawa Ujina');
             });
 
+            it('should trigger when Isawa Kaede is attacking', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.isawaKaede],
+                    defenders: [this.callowDelegate],
+                    ring: 'air'
+                });
+                this.noMoreActions();
+                this.player1.clickPrompt('No');
+                expect(this.player1).toHavePrompt('Resolve Ring Effect');
+                expect(this.player1).toBeAbleToSelectRing('air');
+                expect(this.player1).toBeAbleToSelectRing('void');
+                this.player1.clickPrompt('Don\'t Resolve the Conflict Ring');
+                expect(this.player1).toHavePrompt('Isawa Ujina');
+            });
+
             describe('when triggered', function() {
                 beforeEach(function() {
                     this.noMoreActions();
@@ -69,6 +86,7 @@ describe('Isawa Ujina', function() {
                 it('should only be able to target a character with no fate', function() {
                     expect(this.player1).toHavePrompt('Isawa Ujina');
                     expect(this.player1).toBeAbleToSelect(this.isawaUjina);
+                    expect(this.player1).toBeAbleToSelect(this.isawaKaede);
                     expect(this.player1).toBeAbleToSelect(this.callowDelegate);
                     expect(this.player1).toBeAbleToSelect(this.dojiChallenger);
                     expect(this.player1).not.toBeAbleToSelect(this.dojiHotaru);

--- a/test/server/cards/06-CotE/IsawaUjina.spec.js
+++ b/test/server/cards/06-CotE/IsawaUjina.spec.js
@@ -1,0 +1,133 @@
+describe('Isawa Ujina', function() {
+    integration(function() {
+        describe('Isawa Ujina\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['isawa-ujina', 'adept-of-the-waves', 'fushicho'],
+                        hand: ['know-the-world', 'know-the-world']
+                    },
+                    player2: {
+                        inPlay: ['callow-delegate', 'doji-challenger', 'doji-hotaru']
+                    }
+                });
+                this.isawaUjina = this.player1.findCardByName('isawa-ujina');
+                this.adeptOfTheWaves = this.player1.findCardByName('adept-of-the-waves');
+                this.fushicho = this.player1.findCardByName('fushicho');
+                let knowTheWorlds = this.player1.filterCardsByName('know-the-world');
+                this.knowTheWorld1 = knowTheWorlds[0];
+                this.knowTheWorld2 = knowTheWorlds[1];
+
+                this.callowDelegate = this.player2.findCardByName('callow-delegate');
+                this.dojiChallenger = this.player2.findCardByName('doji-challenger');
+                this.dojiChallenger.fate = 1;
+                this.dojiHotaru = this.player2.findCardByName('doji-hotaru');
+                this.dojiHotaru.fate = 2;
+            });
+
+            it('should trigger after the void ring is claimed (by controller)', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.isawaUjina],
+                    defenders: [this.callowDelegate],
+                    ring: 'void'
+                });
+                this.noMoreActions();
+                expect(this.player1).toHavePrompt('Void Ring');
+                expect(this.player1).toBeAbleToSelect(this.dojiChallenger);
+                expect(this.player1).toBeAbleToSelect(this.dojiHotaru);
+                this.player1.clickCard(this.dojiChallenger);
+                expect(this.player1).toHavePrompt('Isawa Ujina');
+            });
+
+            it('should trigger after the void ring is claimed (by opponent)', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.isawaUjina],
+                    defenders: [this.dojiHotaru],
+                    ring: 'void'
+                });
+                this.noMoreActions();
+                expect(this.player1).toHavePrompt('Isawa Ujina');
+            });
+
+            describe('when triggered', function() {
+                beforeEach(function() {
+                    this.noMoreActions();
+                    this.initiateConflict({
+                        attackers: [this.isawaUjina],
+                        defenders: [this.callowDelegate],
+                        type: 'political',
+                        ring: 'void'
+                    });
+                    this.noMoreActions();
+                    this.player1.clickPrompt('No');
+                    this.player1.clickCard(this.dojiChallenger);
+                });
+
+                it('should only be able to target a character with no fate', function() {
+                    expect(this.player1).toHavePrompt('Isawa Ujina');
+                    expect(this.player1).toBeAbleToSelect(this.isawaUjina);
+                    expect(this.player1).toBeAbleToSelect(this.callowDelegate);
+                    expect(this.player1).toBeAbleToSelect(this.dojiChallenger);
+                    expect(this.player1).not.toBeAbleToSelect(this.dojiHotaru);
+                });
+
+                it('should remove the target from the game', function() {
+                    this.player1.clickCard(this.dojiChallenger);
+                    expect(this.dojiChallenger.location).toBe('removed from game');
+                });
+
+                it('should trigger \'leaves play\' triggers', function() {
+                    this.player1.clickCard(this.callowDelegate);
+                    expect(this.player2).toHavePrompt('Triggered Abilities');
+                    expect(this.player2).toBeAbleToSelect(this.callowDelegate);
+                });
+            });
+
+            it('should trigger multiple times', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.isawaUjina],
+                    defenders: [this.dojiChallenger],
+                    type: 'political',
+                    ring: 'void'
+                });
+                this.noMoreActions();
+                this.player1.clickCard(this.dojiChallenger);
+                expect(this.player1).toHavePrompt('Isawa Ujina');
+                this.player1.clickCard(this.dojiChallenger);
+                expect(this.dojiChallenger.location).toBe('removed from game');
+                this.player1.clickCard(this.knowTheWorld1);
+                this.player1.clickRing('void');
+                this.player1.clickRing('air');
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.callowDelegate],
+                    defenders: [this.adeptOfTheWaves],
+                    type: 'political',
+                    ring: 'void'
+                });
+                this.noMoreActions();
+                expect(this.player1).toHavePrompt('Isawa Ujina');
+                this.player1.clickCard(this.callowDelegate);
+                this.player2.clickPrompt('Pass');
+                expect(this.callowDelegate.location).toBe('removed from game');
+                this.player1.clickCard(this.knowTheWorld2);
+                this.player1.clickRing('void');
+                this.player1.clickRing('earth');
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.fushicho],
+                    defenders: [],
+                    ring: 'void'
+                });
+                this.noMoreActions();
+                this.player1.clickPrompt('No');
+                this.player1.clickCard(this.dojiHotaru);
+                expect(this.player1).toHavePrompt('Isawa Ujina');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Closes #2719 

Includes new RemoveFromGameAction

The new RemoveFromGameAction is a modified version of DiscardFromPlayAction with (particularly) a change to the destination.

Works ok with my tests, but there could be some interactions I have not considered.  Needs review.

RemoveFromGame is also expecting a card that is in play - that is probably not clear from the name of the action.  Any suggestions for a better action name?  Or a way to deal with out of play cards?

