### PR TITLE
Fix for Reclusive Zokojin covert

### DIFF
--- a/server/game/gamesteps/conflict/initiateconflictprompt.js
+++ b/server/game/gamesteps/conflict/initiateconflictprompt.js
@@ -178,7 +178,7 @@ class InitiateConflictPrompt extends UiPrompt {
 
     recalculateCovert() {
         // remove any selected defenders with covert
-        this.selectedDefenders.map(card => {
+        _.each(this.selectedDefenders, card => {
             if(card.isCovert()) {
                 card.covert = false;
                 this.selectedDefenders.splice(this.selectedDefenders.indexOf(card));

--- a/server/game/gamesteps/conflict/initiateconflictprompt.js
+++ b/server/game/gamesteps/conflict/initiateconflictprompt.js
@@ -93,7 +93,6 @@ class InitiateConflictPrompt extends UiPrompt {
         }
 
         return this.selectCard(card);
-
     }
 
     onRingClicked(player, ring) {
@@ -178,7 +177,21 @@ class InitiateConflictPrompt extends UiPrompt {
     }
 
     recalculateCovert() {
+        // remove any selected defenders with covert
+        this.selectedDefenders.map(card => {
+            if(card.isCovert()) {
+                card.covert = false;
+                this.selectedDefenders.splice(this.selectedDefenders.indexOf(card));
+            }
+        });
+
+        // remove any covert in excess of attackers with covert
         let attackersWithCovert = _.size(_.filter(this.conflict.attackers, card => card.isCovert()));
+        while(attackersWithCovert < _.size(this.selectedDefenders)) {
+            this.selectedDefenders.pop().covert = false;
+        }
+
+        // set if any covert remaining
         this.covertRemaining = attackersWithCovert > _.size(this.selectedDefenders);
     }
 
@@ -216,9 +229,6 @@ class InitiateConflictPrompt extends UiPrompt {
     }
 
     removeFromConflict(card) {
-        if(card.isCovert() && !this.covertRemaining) {
-            this.selectedDefenders.pop().covert = false;
-        }
         this.conflict.removeFromConflict(card);
     }
 

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -558,6 +558,17 @@ class PlayerInteractionWrapper {
     }
 
     /**
+     * Player's action of passing a conflict
+     */
+    passConflict() {
+        if(!this.hasPrompt('Initiate Conflict')) {
+            throw new Error(`${this.name} can't pass their conflict, because they are not being prompted to declare one`);
+        }
+        this.clickPrompt('Pass Conflict');
+        this.clickPrompt('Yes');
+    }
+
+    /**
      * Selects a stronghold province at the beginning of the game
      * @param {!String} card - the province to select
      */

--- a/test/server/cards/04.6-EU/ReclusiveZokujin.spec.js
+++ b/test/server/cards/04.6-EU/ReclusiveZokujin.spec.js
@@ -11,13 +11,18 @@ describe('Reclusive Zokujin', function() {
                     },
                     player2: {
                         hand: ['cloud-the-mind', 'misinformation', 'ornate-fan'],
-                        inPlay: ['sinister-soshi', 'bayushi-liar', 'steward-of-law']
+                        inPlay: ['sinister-soshi', 'bayushi-liar', 'steward-of-law', 'togashi-mitsu']
                     }
                 });
                 this.player2.player.showBid = 5;
                 this.favorableGround = this.player1.placeCardInProvince('favorable-ground');
                 this.reclusiveZokujin = this.player1.findCardByName('reclusive-zokujin');
+                this.otomoCourtier = this.player1.findCardByName('otomo-courtier');
                 this.bayushiLiar = this.player2.findCardByName('bayushi-liar');
+                this.stewardOfLaw = this.player2.findCardByName('steward-of-law');
+                this.togashiMitsu = this.player2.findCardByName('togashi-mitsu');
+                this.shamefulDisplayPlayer1 = this.player1.findCardByName('shameful-display', 'province 1');
+                this.shamefulDisplayPlayer2 = this.player2.findCardByName('shameful-display', 'province 1');
             });
 
             it('should give covert during earth conflicts', function() {
@@ -160,6 +165,67 @@ describe('Reclusive Zokujin', function() {
                 this.player1.clickPrompt('Pay Costs first');
                 expect(this.player1).toBeAbleToSelect(this.reclusiveZokujin);
                 expect(this.player1).not.toBeAbleToSelect('otomo-courtier');
+            });
+
+            it('should not prompt for covert during non-earth conflicts (even if earth ring clicked initially)', function() {
+                this.noMoreActions();
+                expect(this.player1).toHavePrompt('Initiate Conflict');
+                this.player1.clickRing('earth');
+                this.player1.clickCard(this.reclusiveZokujin);
+                this.player1.clickCard(this.shamefulDisplayPlayer2);
+                this.player1.clickRing('air');
+                this.player1.clickPrompt('Initiate Conflict');
+                expect(this.player1).not.toHavePrompt('Choose Covert');
+                expect(this.player2).toHavePrompt('Choose defenders');
+            });
+
+            it('should not keep covert selection if ring changed from earth during declaring attackers', function() {
+                this.noMoreActions();
+                expect(this.player1).toHavePrompt('Initiate Conflict');
+                this.player1.clickRing('earth');
+                this.player1.clickCard(this.reclusiveZokujin);
+                this.player1.clickCard(this.stewardOfLaw);
+                this.player1.clickCard(this.shamefulDisplayPlayer2);
+                this.player1.clickRing('air');
+                this.player1.clickPrompt('Initiate Conflict');
+                expect(this.player2).toHavePrompt('Choose defenders');
+                this.player2.clickCard(this.stewardOfLaw);
+                this.player2.clickPrompt('Done');
+                expect(this.stewardOfLaw.isParticipating()).toBe(true);
+            });
+
+            it('should not keep covert selection if removed from conflict during declaring attackers', function() {
+                this.noMoreActions();
+                expect(this.player1).toHavePrompt('Initiate Conflict');
+                this.player1.clickRing('earth');
+                this.player1.clickCard(this.reclusiveZokujin);
+                this.player1.clickCard(this.otomoCourtier);
+                this.player1.clickCard(this.stewardOfLaw);
+                this.player1.clickCard(this.shamefulDisplayPlayer2);
+                this.player1.clickCard(this.reclusiveZokujin);
+                this.player1.clickPrompt('Initiate Conflict');
+                expect(this.player2).toHavePrompt('Choose defenders');
+                this.player2.clickCard(this.stewardOfLaw);
+                this.player2.clickPrompt('Done');
+                expect(this.stewardOfLaw.isParticipating()).toBe(true);
+            });
+
+            it('should not remain coverted if ring changed to earth when defending', function() {
+                this.noMoreActions();
+                this.player1.passConflict();
+                this.noMoreActions();
+                expect(this.player2).toHavePrompt('Initiate Conflict');
+                this.player2.clickRing('air');
+                this.player2.clickCard(this.togashiMitsu);
+                this.player2.clickCard(this.reclusiveZokujin);
+                this.player2.clickCard(this.shamefulDisplayPlayer1);
+                this.player2.clickRing('earth');
+                this.player2.clickPrompt('Initiate Conflict');
+                expect(this.player2).toHavePrompt('Choose Covert');
+                this.player2.clickCard(this.otomoCourtier);
+                this.player1.clickCard(this.reclusiveZokujin);
+                this.player1.clickPrompt('Done');
+                expect(this.reclusiveZokujin.isParticipating()).toBe(true);
             });
         });
     });

--- a/test/server/gamesteps/initiateconflictprompt.spec.js
+++ b/test/server/gamesteps/initiateconflictprompt.spec.js
@@ -232,7 +232,7 @@ describe('InitateConflictPrompt: ', function() {
                     describe('and it\'s currently participating,', function() {
                         beforeEach(function() {
                             this.conflictSpy.attackers.push(this.cardSpy);
-                            this.defenderSpy = jasmine.createSpyObj('defender', ['checkRestrictions', 'canBeBypassedByCovert']);
+                            this.defenderSpy = jasmine.createSpyObj('defender', ['checkRestrictions', 'canBeBypassedByCovert', 'isCovert']);
                             this.defenderSpy.covert = true;
                             this.prompt.selectedDefenders = [this.defenderSpy];
                             this.returnValue = this.prompt.onCardClicked(this.playerSpy, this.cardSpy);
@@ -339,6 +339,9 @@ describe('InitateConflictPrompt: ', function() {
                 describe('if there is covert remaining', function() {
                     beforeEach(function() {
                         this.prompt.covertRemaining = true;
+                        let attacker = jasmine.createSpyObj('attacker', ['isCovert']);
+                        attacker.isCovert.and.returnValue(true);
+                        this.prompt.conflict.attackers.push(attacker);
                         this.returnValue = this.prompt.onCardClicked(this.playerSpy, this.cardSpy);
                     });
 


### PR DESCRIPTION
Closes #2661 

Includes commit 9aaeede (`passConflilct()` helper function)

`recalculateCovert()`, that is called after each click in declare attackers, will now:

* remove any coverted defenders that have somehow now gained covert, and
* remove any coverted defenders until the number of attackers with covert equals (or is fewer than) the number of coverted defenders

I also added a few tests for Reclusive Zokujin to test for this situation and also had to slightly change the `initiateconflictprompt.spec` to mock the `isCovert()` function.