### PR TITLE
CotE -Severed From the Stream

### DIFF
--- a/server/game/cards/06-CotE/SeveredFromTheStream.js
+++ b/server/game/cards/06-CotE/SeveredFromTheStream.js
@@ -1,0 +1,21 @@
+const DrawCard = require('../../drawcard.js');
+const AbilityDsl = require('../../abilitydsl');
+
+class SeveredFromTheStream extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Return player\'s rings',
+            gameAction: AbilityDsl.actions.returnRing(context => {
+                if(context.player.opponent && context.player.getGloryCount() < context.player.opponent.getGloryCount()) {
+                    return { target: context.player.getClaimedRings() };
+                } else if(context.player.opponent && context.player.getGloryCount() > context.player.opponent.getGloryCount()) {
+                    return { target: context.player.opponent.getClaimedRings() };
+                }
+            })
+        });
+    }
+}
+
+SeveredFromTheStream.id = 'severed-from-the-stream';
+
+module.exports = SeveredFromTheStream;

--- a/server/game/gamesteps/conflictphase.js
+++ b/server/game/gamesteps/conflictphase.js
@@ -61,7 +61,7 @@ class ConflictPhase extends Phase {
 
     claimImperialFavor() {
         let gloryTotals = this.game.getPlayersInFirstPlayerOrder().map(player => {
-            return player.cardsInPlay.reduce((total, card) => total + card.getContributionToImperialFavor(), player.getClaimedRings().length + player.gloryModifier);
+            return player.getGloryCount();
         });
         let winner = this.game.getFirstPlayer();
         if(winner.opponent) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -839,6 +839,10 @@ class Player extends GameObject {
         return _.filter(this.game.rings, ring => ring.isConsideredClaimed(this));
     }
 
+    getGloryCount() {
+        return this.cardsInPlay.reduce((total, card) => total + card.getContributionToImperialFavor(), this.getClaimedRings().length + this.gloryModifier);
+    }
+
     /**
      * Marks that this player controls the favor for the relevant conflict type
      */

--- a/test/server/cards/06-CotE/SeveredFromTheStream.spec.js
+++ b/test/server/cards/06-CotE/SeveredFromTheStream.spec.js
@@ -24,7 +24,7 @@ describe('Severed From the Stream', function() {
                 this.player1.claimRing('fire');
                 this.player2.claimRing('void');
             });
-                       
+
             it('should return all rings from the player with the lowest glory count', function() {
                 expect(this.player1.player.getGloryCount()).toBe(2 + 2);
                 expect(this.player2.player.getGloryCount()).toBe(2 + 1);

--- a/test/server/cards/06-CotE/SeveredFromTheStream.spec.js
+++ b/test/server/cards/06-CotE/SeveredFromTheStream.spec.js
@@ -1,0 +1,79 @@
+describe('Severed From the Stream', function() {
+    integration(function() {
+        describe('Severed From the Stream\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['adept-of-the-waves'],
+                        hand: ['severed-from-the-stream','against-the-waves']
+                    },
+                    player2: {
+                        inPlay: ['doji-challenger'],
+                        dynastyDiscard: ['the-imperial-palace']
+                    }
+                });
+                this.adeptOfTheWaves = this.player1.findCardByName('adept-of-the-waves');
+                this.againstTheWaves = this.player1.findCardByName('against-the-waves');
+                this.severedFromTheStream = this.player1.findCardByName('severed-from-the-stream');
+
+                this.dojiChallenger = this.player2.findCardByName('doji-challenger');
+                this.theImperialPalace = this.player2.findCardByName('the-imperial-palace');
+
+                this.player1.claimRing('air');
+                this.player1.claimRing('fire');
+                this.player2.claimRing('void');
+            });
+                       
+            it('should return all rings from the player with the lowest glory count', function() {
+                expect(this.player1.player.getGloryCount()).toBe(2 + 2);
+                expect(this.player2.player.getGloryCount()).toBe(2 + 1);
+                expect(this.player1).toHavePrompt('Action Window');
+                this.player1.clickCard(this.severedFromTheStream);
+                expect(this.player2).toHavePrompt('Action Window');
+                expect(this.game.rings.air.claimedBy).toBe(this.player1.player.name);
+                expect(this.game.rings.fire.claimedBy).toBe(this.player1.player.name);
+                expect(this.game.rings.void.claimed).toBe(false);
+            });
+
+            it('should not count bowed characters in the glory count', function() {
+                this.player1.clickCard(this.againstTheWaves);
+                this.player1.clickCard(this.adeptOfTheWaves);
+                this.player2.pass();
+                expect(this.player1.player.getGloryCount()).toBe(2);
+                expect(this.player2.player.getGloryCount()).toBe(2 + 1);
+                expect(this.player1).toHavePrompt('Action Window');
+                this.player1.clickCard(this.severedFromTheStream);
+                expect(this.player2).toHavePrompt('Action Window');
+                expect(this.game.rings.air.claimed).toBe(false);
+                expect(this.game.rings.fire.claimed).toBe(false);
+                expect(this.game.rings.void.claimedBy).toBe(this.player2.player.name);
+            });
+
+            it('should count the imperial palace in the glory count', function() {
+                this.player2.placeCardInProvince(this.theImperialPalace, 'province 1');
+                expect(this.player1.player.getGloryCount()).toBe(2 + 2);
+                expect(this.player2.player.getGloryCount()).toBe(2 + 1 + 3);
+                expect(this.player1).toHavePrompt('Action Window');
+                this.player1.clickCard(this.severedFromTheStream);
+                expect(this.player2).toHavePrompt('Action Window');
+                expect(this.game.rings.air.claimed).toBe(false);
+                expect(this.game.rings.fire.claimed).toBe(false);
+                expect(this.game.rings.void.claimedBy).toBe(this.player2.player.name);
+            });
+
+            it('should not trigger if player\'s glory counts are equal ', function() {
+                this.player2.claimRing('water');
+                expect(this.player1.player.getGloryCount()).toBe(2 + 2);
+                expect(this.player2.player.getGloryCount()).toBe(2 + 2);
+                expect(this.player1).toHavePrompt('Action Window');
+                this.player1.clickCard(this.severedFromTheStream);
+                expect(this.player1).toHavePrompt('Action Window');
+                expect(this.game.rings.air.claimedBy).toBe(this.player1.player.name);
+                expect(this.game.rings.fire.claimedBy).toBe(this.player1.player.name);
+                expect(this.game.rings.void.claimedBy).toBe(this.player2.player.name);
+                expect(this.game.rings.water.claimedBy).toBe(this.player2.player.name);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Closes #2849 

Please note that I added a new function `getGloryCount()` to player and referenced that in both this implementation and `conflictphase.js` (`claimImperialFavor`).

Also, I am assuming that this cannot be triggered if glory counts are equal.  This may change in the future if anything triggers off "Perform a glory count".