### PR TITLE
removed potential self-referencing gamestate refs

### DIFF
--- a/server/game/conflict.js
+++ b/server/game/conflict.js
@@ -44,9 +44,9 @@ class Conflict extends GameObject {
             defenderSkill: this.defenderSkill,
             type: this.conflictType,
             elements: this.elements,
-            attackerWins: this.attackers.length > 0 && this.attackerSkill >= this.defenderSkill,
-            breaking: this.conflictProvince && (this.conflictProvince.getStrength() - (this.attackerSkill - this.defenderSkill) <= 0),
-            unopposed: !(this.defenders && this.defenders.length > 0)
+            attackerWins: (this.attackers.length > 0 && this.attackerSkill >= this.defenderSkill) ? true : false,
+            breaking: (this.conflictProvince && (this.conflictProvince.getStrength() - (this.attackerSkill - this.defenderSkill) <= 0)) ? true : false,
+            unopposed: (this.defenders && (this.defenders.length > 0)) ? false : true
         };
     }
 

--- a/server/game/ring.js
+++ b/server/game/ring.js
@@ -113,7 +113,7 @@ class Ring extends EffectSource {
             claimedBy: this.claimedBy,
             conflictType: this.conflictType,
             contested: this.contested,
-            selected: this.game.currentConflict && this.game.currentConflict.conflictRing === this.element,
+            selected: (this.game.currentConflict && this.game.currentConflict.conflictRing === this.element) ? true : false,
             element: this.element,
             fate: this.fate,
             menu: this.getMenu()


### PR DESCRIPTION
Forced members of conflict summary to be boolean types, there were some cases where they *might* have ended up as object references. I don't think this is causing the server loops, but it can't hurt to clean up. 