### PR TITLE
Add location to chat message for Iuchi Wayfinder

### DIFF
--- a/server/game/cards/01-Core/IuchiWayfinder.js
+++ b/server/game/cards/01-Core/IuchiWayfinder.js
@@ -15,7 +15,10 @@ class IuchiWayfinder extends DrawCard {
                 cardType: CardTypes.Province,
                 location: Locations.Provinces,
                 controller: Players.Opponent,
-                gameAction: AbilityDsl.actions.lookAt()
+                gameAction: AbilityDsl.actions.lookAt(context => ({
+                    message: '{0} sees {1} in {2}',
+                    messageArgs: (cards) => [context.source, cards[0], cards[0].location]
+                }))
             })
         });
     }

--- a/test/server/cards/01-Core/IuchiWayfinder.spec.js
+++ b/test/server/cards/01-Core/IuchiWayfinder.spec.js
@@ -23,11 +23,10 @@ describe('Iuchi Wayfinder', function() {
             });
 
             it('should display a message in chat when a province is chosen', function() {
-                this.chat = spyOn(this.game, 'addMessage');
                 this.iuchiWayfinder = this.player1.playCharacterFromHand('iuchi-wayfinder');
                 this.player1.clickCard(this.iuchiWayfinder);
                 this.player1.clickCard(this.shamefulDisplay1);
-                expect(this.chat).toHaveBeenCalledWith('{0} sees {1}', this.iuchiWayfinder, [this.shamefulDisplay1]);
+                expect(this.getChatLogs(1)).toContain('Iuchi Wayfinder sees Shameful Display in province 1');
             });
         });
     });


### PR DESCRIPTION
Not a big deal, but this is just something I've noticed that would be very useful for spectators.  If you are spectating you have no idea which province was actually looked at with iuchi wayfinder.