### PR TITLE
Gossip's "select a card"-menu fix

### DIFF
--- a/client/GameComponents/CardNameLookup.jsx
+++ b/client/GameComponents/CardNameLookup.jsx
@@ -27,7 +27,7 @@ class CardNameLookup extends React.Component {
         return (
             <div>
                 <Typeahead labelKey={ 'label' } options={ [...new Set(Object.values(this.props.cards).map(card => card.name))] } dropup onChange={ this.onCardNameChange } />
-                <button type='button' onClick={ this.onDoneClick } className='btn btn-primary'>Done</button>
+                <button type='button' disabled={ !this.state.cardName } onClick={ this.onDoneClick } className='btn btn-primary'>Done</button>
             </div>);
     }
 }

--- a/less/application.less
+++ b/less/application.less
@@ -227,6 +227,7 @@ ul.htp-sub-list {
     width: 100%;
     height: 34px;
     padding: 6px 12px;
+    margin: 5px 0;
     background-color: #fff;
     background-image: none;
     border: 1px solid #ccc;
@@ -236,4 +237,11 @@ ul.htp-sub-list {
     -webkit-transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out;
     -o-transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
     transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+}
+
+.form-horizontal {
+  .form-group {
+    margin-left: 0;
+    margin-right: 0;
+  }
 }

--- a/less/gameboard/menu.less
+++ b/less/gameboard/menu.less
@@ -30,7 +30,6 @@
     border-top-right-radius: 0;
     border-top-left-radius: 0;
     max-height: 380px;
-    overflow-y: auto;
 }
 
 .menu-pane button {


### PR DESCRIPTION
- Gossip menu was not functional because selection menu hid behind the container.
- Fixed some padding issues in deck selector