### PR TITLE
Bugfix - Illustrious Forge

### DIFF
--- a/server/game/GameActions/GameAction.ts
+++ b/server/game/GameActions/GameAction.ts
@@ -11,6 +11,7 @@ type PlayerOrRingOrCardOrToken = Player | Ring | BaseCard | StatusToken;
 
 export interface GameActionProperties {
     target?: PlayerOrRingOrCardOrToken | PlayerOrRingOrCardOrToken[];
+    optional?: boolean;
 }
 
 export class GameAction {
@@ -21,7 +22,7 @@ export class GameAction {
     name = '';
     cost = '';
     effect = '';
-    defaultProperties: GameActionProperties = {};
+    defaultProperties: GameActionProperties = { optional: false };
     getDefaultTargets: (context: AbilityContext) => any = context => this.defaultTargets(context);
 
     constructor(propertyFactory: GameActionProperties | ((context?: AbilityContext) => GameActionProperties) = {}) {
@@ -125,6 +126,11 @@ export class GameAction {
 
     isEventFullyResolved(event: Event, target: any, context: AbilityContext, additionalProperties = {}): boolean { // eslint-disable-line no-unused-vars
         return !event.cancelled && event.name === this.eventName;
+    }
+
+    isOptional(context: AbilityContext, additionalProperties = {}): boolean {
+        const { optional } = this.getProperties(context, additionalProperties);
+        return optional;
     }
 
     moveFateEventCondition(event): boolean {

--- a/server/game/GameActions/ResolveElementAction.ts
+++ b/server/game/GameActions/ResolveElementAction.ts
@@ -7,7 +7,6 @@ import { RingAction, RingActionProperties} from './RingAction';
 import { EventNames } from '../Constants';
 
 export interface ResolveElementProperties extends RingActionProperties {
-    optional?: boolean;
     physicalRing?: Ring;
     player?: Player;
 }
@@ -16,7 +15,6 @@ export class ResolveElementAction extends RingAction {
     name = 'resolveElement';
     eventName = EventNames.OnResolveRingElement;
     effect = 'resolve {0} effect';
-    defaultProperties: ResolveElementProperties = { optional: true };
     constructor(properties: ((context: AbilityContext) => ResolveElementProperties) | ResolveElementProperties) {
         super(properties);
     }

--- a/server/game/GameActions/SelectCardAction.ts
+++ b/server/game/GameActions/SelectCardAction.ts
@@ -13,7 +13,6 @@ export interface SelectCardProperties extends CardActionProperties {
     player?: Players;
     cardType?: CardTypes | CardTypes[];
     controller?: Players;
-    optional?: boolean;
     location?: Locations | Locations[];
     cardCondition?: (card: BaseCard, context: AbilityContext) => boolean;
     targets?: boolean;
@@ -57,14 +56,14 @@ export class SelectCardAction extends CardGameAction {
 
     canAffect(card: BaseCard, context: AbilityContext, additionalProperties = {}): boolean {
         let properties = this.getProperties(context, additionalProperties);
-        let player = properties.targets && context.choosingPlayerOverride || (properties.player === Players.Opponent ? context.player.opponent : context.player);
+        let player = properties.targets && context.choosingPlayerOverride || properties.player === Players.Opponent && context.player.opponent || context.player;
         return properties.selector.canTarget(card, context, player);
     }
 
     hasLegalTarget(context: AbilityContext, additionalProperties = {}): boolean {
         let properties = this.getProperties(context, additionalProperties);
-        let player = properties.targets && context.choosingPlayerOverride || (properties.player === Players.Opponent ? context.player.opponent : context.player);
-        return properties.selector.optional || properties.selector.hasEnoughTargets(context, player);
+        let player = properties.targets && context.choosingPlayerOverride || properties.player === Players.Opponent && context.player.opponent || context.player;
+        return properties.selector.hasEnoughTargets(context, player);
     }
 
     addEventsToArray(events, context: AbilityContext, additionalProperties = {}): void {

--- a/server/game/ThenAbility.js
+++ b/server/game/ThenAbility.js
@@ -23,6 +23,17 @@ class ThenAbility extends BaseAbility {
         });
     }
 
+    checkGameActionsForPotential(context) {
+        if(super.checkGameActionsForPotential(context)) {
+            return true;
+        } else if(this.gameAction.every(gameAction => gameAction.isOptional(context)) && this.properties.then) {
+            const then = typeof(this.properties.then) === 'function' ? this.properties.then(context) : this.properties.then;
+            const thenAbility = new ThenAbility(this.game, this.card, then);
+            return thenAbility.meetsRequirements(thenAbility.createContext(context.player)) === '';
+        }
+        return false;
+    }
+
     displayMessage(context) {
         if(this.properties.message) {
             let messageArgs = [context.player, context.source, context.target];

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -98,12 +98,16 @@ class BaseAbility {
             return 'cost';
         }
         if(this.targets.length === 0) {
-            if(this.gameAction.length > 0 && !this.gameAction.some(gameAction => gameAction.hasLegalTarget(context))) {
+            if(this.gameAction.length > 0 && !this.checkGameActionsForPotential(context)) {
                 return 'condition';
             }
             return '';
         }
         return this.canResolveTargets(context) ? '' : 'target';
+    }
+
+    checkGameActionsForPotential(context) {
+        return this.gameAction.some(gameAction => gameAction.hasLegalTarget(context));
     }
 
     /**

--- a/server/game/cards/05-UotE/PeasantsAdvice.js
+++ b/server/game/cards/05-UotE/PeasantsAdvice.js
@@ -11,7 +11,6 @@ class PeasantsAdvice extends DrawCard {
             target: {
                 cardType: CardTypes.Province,
                 location: Locations.Provinces,
-                cardCondition: card => card.facedown || card.controller.getSourceList(card.location).some(provinceCard => provinceCard.isDynasty && !provinceCard.facedown),
                 gameAction: AbilityDsl.actions.sequential([
                     AbilityDsl.actions.lookAt(),
                     AbilityDsl.actions.selectCard(context => ({

--- a/server/game/cards/05-UotE/PeasantsAdvice.js
+++ b/server/game/cards/05-UotE/PeasantsAdvice.js
@@ -11,13 +11,17 @@ class PeasantsAdvice extends DrawCard {
             target: {
                 cardType: CardTypes.Province,
                 location: Locations.Provinces,
+                cardCondition: card => card.facedown || card.controller.getSourceList(card.location).some(provinceCard => provinceCard.isDynasty && !provinceCard.facedown),
                 gameAction: AbilityDsl.actions.sequential([
                     AbilityDsl.actions.lookAt(),
-                    AbilityDsl.actions.cardMenu(context => ({
-                        activePromptTitle: 'Choose a card to return to owner\'s deck',
-                        cards: context.target.controller.getSourceList(context.target.location).filter(card => card.isDynasty && !card.facedown),
-                        choices: ['Done'],
-                        handlers: [() => this.game.addMessage('{0} chooses not to return a dynasty card to its owner\'s deck', context.player)],
+                    AbilityDsl.actions.selectCard(context => ({
+                        activePromptTitle: 'Choose a faceup card to return to its owner\'s deck',
+                        cardCondition: card =>
+                            card.location === context.target.location &&
+                            card.controller === context.target.controller &&
+                            card.isDynasty && !card.facedown,
+                        location: Locations.Provinces,
+                        optional: true,
                         message: '{0} chooses to shuffle {1} into its owner\'s deck',
                         messageArgs: card => [context.player, card],
                         gameAction: AbilityDsl.actions.moveCard({
@@ -33,6 +37,6 @@ class PeasantsAdvice extends DrawCard {
     }
 }
 
-PeasantsAdvice.id = 'peasant-s-advice'; // This is a guess at what the id might be - please check it!!!
+PeasantsAdvice.id = 'peasant-s-advice';
 
 module.exports = PeasantsAdvice;

--- a/server/game/cards/06-CotE/IllustriousForge.js
+++ b/server/game/cards/06-CotE/IllustriousForge.js
@@ -13,9 +13,8 @@ class IllustriousForge extends ProvinceCard {
             gameAction: AbilityDsl.actions.sequential([
                 AbilityDsl.actions.cardMenu(context => ({
                     activePromptTitle: 'Choose an attachment',
-                    cards: context.player.conflictDeck.first(5).filter(card =>
-                        card.type === CardTypes.Attachment
-                    ),
+                    cards: context.player.conflictDeck.first(5),
+                    cardCondition: card => card.type === CardTypes.Attachment,
                     choices: ['Take nothing'],
                     handlers: [() => {
                         this.game.addMessage('{0} takes nothing', context.player);

--- a/test/server/cards/05-UotE/PeasantsAdvice.spec.js
+++ b/test/server/cards/05-UotE/PeasantsAdvice.spec.js
@@ -24,11 +24,13 @@ describe('Peasant\'s Advice', function() {
                 expect(this.seppunGuardsman.isDishonored).toBe(true);
             });
 
-            it('should display a text message about a provice with a facedown card in it', function() {
+            it('should display a chat message about a provice with a facedown card in it', function() {
                 this.shibaTsukune.facedown = true;
                 this.player1.clickCard('peasant-s-advice');
                 this.player1.clickCard(this.shamefulDisplay);
                 this.seppunGuardsman = this.player1.clickCard('seppun-guardsman');
+                expect(this.player1).not.toHavePrompt('Choose a faceup card to return to its owner\'s deck');
+                expect(this.player1).not.toHavePromptButton('Done');
                 expect(this.player2).toHavePrompt('Action Window');
                 expect(this.getChatLogs(5)).toContain('Peasant\'s Advice sees Shameful Display');
             });
@@ -38,27 +40,29 @@ describe('Peasant\'s Advice', function() {
                 this.player1.clickCard('peasant-s-advice');
                 this.player1.clickCard(this.shamefulDisplay);
                 this.seppunGuardsman = this.player1.clickCard('seppun-guardsman');
-                expect(this.player1).toHavePrompt('Choose a card to return to owner\'s deck');
-                expect(this.player1).toHavePromptButton('Shiba Tsukune');
+                expect(this.player1).toHavePrompt('Choose a faceup card to return to its owner\'s deck');
                 expect(this.player1).toHavePromptButton('Done');
+                expect(this.player1).toBeAbleToSelect(this.shibaTsukune);
                 this.player1.clickPrompt('Done');
                 expect(this.player2).toHavePrompt('Action Window');
                 expect(this.getChatLogs(5)).not.toContain('Peasant\'s Advice sees Shameful Display');
                 expect(this.shibaTsukune.location).toBe('province 1');
             });
 
-            it('should both display a text message and offer the option to shuffle a faceup card in a facedown province', function() {
+            it('should both display a chat message and offer the option to shuffle a faceup card in a facedown province', function() {
                 this.player1.clickCard('peasant-s-advice');
                 this.player1.clickCard(this.shamefulDisplay);
                 this.spy = spyOn(this.player2.player, 'moveCard').and.callThrough();
                 this.seppunGuardsman = this.player1.clickCard('seppun-guardsman');
                 expect(this.getChatLogs(5)).toContain('Peasant\'s Advice sees Shameful Display');
-                expect(this.player1).toHavePrompt('Choose a card to return to owner\'s deck');
-                expect(this.player1).toHavePromptButton('Shiba Tsukune');
+                expect(this.player1).toHavePrompt('Choose a faceup card to return to its owner\'s deck');
                 expect(this.player1).toHavePromptButton('Done');
-                this.player1.clickPrompt('Shiba Tsukune');
+                expect(this.player1).toBeAbleToSelect(this.shibaTsukune);
+                this.player1.clickCard(this.shibaTsukune);
                 expect(this.player2).toHavePrompt('Action Window');
                 expect(this.getChatLogs(5)).toContain('Peasant\'s Advice sees Shameful Display');
+                expect(this.getChatLogs(2)).toContain('player1 chooses to shuffle Shiba Tsukune into its owner\'s deck');
+                expect(this.getChatLogs(1)).toContain('player2 is shuffling their dynasty deck');
                 expect(this.spy).toHaveBeenCalledWith(this.shibaTsukune, 'dynasty deck', { bottom: false });
                 expect(this.player2.player.getDynastyCardInProvince('province 1')).not.toBeUndefined();
             });

--- a/test/server/cards/06-CotE/IllustriousForge.spec.js
+++ b/test/server/cards/06-CotE/IllustriousForge.spec.js
@@ -9,7 +9,7 @@ describe('Illustrious Forge', function() {
                     },
                     player2: {
                         inPlay: ['border-rider', 'battle-maiden-recruit'],
-                        hand: ['fine-katana', 'finger-of-jade', 'tattooed-wanderer', 'force-of-the-river', 'censure'],
+                        hand: ['fine-katana', 'finger-of-jade', 'tattooed-wanderer', 'force-of-the-river', 'censure', 'talisman-of-the-sun'],
                         provinces: ['illustrious-forge']
                     }
                 });
@@ -23,6 +23,7 @@ describe('Illustrious Forge', function() {
                 this.tattooedWanderer = this.player2.findCardByName('tattooed-wanderer', 'hand');
                 this.forceOfTheRiver = this.player2.findCardByName('force-of-the-river', 'hand');
                 this.censure = this.player2.findCardByName('censure', 'hand');
+                this.talismanOfTheSun = this.player2.findCardByName('talisman-of-the-sun', 'hand');
 
                 this.player2.player.moveCard(this.censure, 'conflict deck');
                 this.player2.player.moveCard(this.fineKatana, 'conflict deck');
@@ -30,7 +31,8 @@ describe('Illustrious Forge', function() {
                 this.player2.player.moveCard(this.tattooedWanderer, 'conflict deck');
                 this.player2.player.moveCard(this.forceOfTheRiver, 'conflict deck');
 
-                this.illustriousForge = this.player2.findCardByName('illustrious-forge');
+                this.illustriousForge = this.player2.findCardByName('illustrious-forge', 'province 1');
+                this.shamefulDisplay = this.player2.findCardByName('shameful-display', 'province 2');
             });
 
             it('should trigger when province is revealed', function() {
@@ -96,6 +98,58 @@ describe('Illustrious Forge', function() {
                 expect(this.player2).toHavePrompt('Choose defenders');
                 expect(this.getChatLogs(3)).toContain('player2 chooses to attach Fine Katana to Border Rider');
                 expect(this.getChatLogs(2)).toContain('player2 is shuffling their conflict deck');
+            });
+
+            it('should still prompt and shuffle the deck if there are no attachments in the top 5', function() {
+                this.player2.player.moveCard(this.censure, 'hand');
+                this.player2.player.moveCard(this.fineKatana, 'hand');
+                this.player2.player.moveCard(this.fingerOfJade, 'hand');
+                this.player2.player.moveCard(this.tattooedWanderer, 'hand');
+                this.player2.player.moveCard(this.forceOfTheRiver, 'hand');
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.adeptOfTheWaves]
+                });
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.illustriousForge);
+                this.player2.clickCard(this.illustriousForge);
+                expect(this.player2).toHavePrompt('Choose an attachment');
+                expect(this.player2).toHavePromptButton('Take nothing');
+                expect(this.player2).toHaveDisabledPromptButton('Supernatural Storm (5)');
+                expect(this.getChatLogs(1)).toContain('player2 uses Illustrious Forge to search the top 5 cards of their conflict deck for an attachment and put it into play');
+                this.player2.clickPrompt('Take nothing');
+                expect(this.getChatLogs(3)).toContain('player2 takes nothing');
+                expect(this.getChatLogs(2)).toContain('player2 is shuffling their conflict deck');
+            });
+
+            it('should interact with Talisman correctly', function() {
+                this.player2.player.moveCard(this.censure, 'hand');
+                this.player2.player.moveCard(this.fineKatana, 'hand');
+                this.player2.player.moveCard(this.fingerOfJade, 'hand');
+                this.player2.player.moveCard(this.tattooedWanderer, 'hand');
+                this.player2.player.moveCard(this.forceOfTheRiver, 'hand');
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.adeptOfTheWaves],
+                    defenders: [this.borderRider],
+                    province: this.shamefulDisplay
+                });
+                this.player2.clickCard(this.talismanOfTheSun);
+                this.player2.clickCard(this.borderRider);
+                expect(this.borderRider.attachments).toContain(this.talismanOfTheSun);
+                this.player1.pass();
+                this.player2.clickCard(this.talismanOfTheSun);
+                this.player2.clickCard(this.illustriousForge);
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.illustriousForge);
+                this.player2.clickCard(this.illustriousForge);
+                expect(this.player2).toHavePrompt('Choose an attachment');
+                expect(this.player2).toHavePromptButton('Take nothing');
+                expect(this.player2).toHaveDisabledPromptButton('Supernatural Storm (5)');
+                expect(this.getChatLogs(1)).toContain('player2 uses Illustrious Forge to search the top 5 cards of their conflict deck for an attachment and put it into play');
+                this.player2.clickPrompt('Take nothing');
+                expect(this.getChatLogs(4)).toContain('player2 takes nothing');
+                expect(this.getChatLogs(3)).toContain('player2 is shuffling their conflict deck');
             });
         });
     });

--- a/test/server/cards/07-WotW/Aranat.spec.js
+++ b/test/server/cards/07-WotW/Aranat.spec.js
@@ -21,20 +21,22 @@ describe('Aranat', function() {
                 this.shamefulDisplay = this.player2.findCardByName('shameful-display');
 
                 this.player1.clickCard(this.aranat);
-                this.player1.clickPrompt('1');
             });
 
             it('should trigger when Aranat is played', function() {
+                this.player1.clickPrompt('1');
                 expect(this.player1).toHavePrompt('Triggered Abilities');
                 expect(this.player1).toBeAbleToSelect(this.aranat);
             });
 
             it('should prompt the opponent to flip provinces', function() {
+                this.player1.clickPrompt('1');
                 this.player1.clickCard(this.aranat);
                 expect(this.player2).toHavePrompt('Aranat');
             });
 
             it('should place fate on Aranat equal to the number of facedown provinces', function() {
+                this.player1.clickPrompt('1');
                 expect(this.fertileFields.facedown).toBe(true);
                 expect(this.aranat.fate).toBe(1);
                 this.player1.clickCard(this.aranat);
@@ -46,6 +48,7 @@ describe('Aranat', function() {
             });
 
             it('should not allow revealing the SH province', function() {
+                this.player1.clickPrompt('1');
                 expect(this.fertileFields.facedown).toBe(true);
                 expect(this.shamefulDisplay.facedown).toBe(true);
                 expect(this.aranat.fate).toBe(1);
@@ -62,6 +65,7 @@ describe('Aranat', function() {
             it('should not give any fate when all provinces are revealed', function() {
                 this.shamefulDisplay.facedown = false;
                 let player2Fate = this.player2.fate;
+                this.player1.clickPrompt('1');
                 expect(this.aranat.fate).toBe(1);
                 this.player1.clickCard(this.aranat);
                 this.player2.clickCard(this.fertileFields);
@@ -78,11 +82,12 @@ describe('Aranat', function() {
             });
 
             it('should not prompt the opponent when all non-SH provinces are revealed', function() {
-                expect(this.aranat.fate).toBe(1);
                 this.fertileFields.facedown = false;
                 this.entrenchedPosition.facedown = false;
                 this.pilgrimage.facedown = false;
                 this.rallyToTheCause.facedown = false;
+                this.player1.clickPrompt('1');
+                expect(this.aranat.fate).toBe(1);
                 this.player1.clickCard(this.aranat);
                 expect(this.aranat.fate).toBe(2);
                 expect(this.player2).toHavePrompt('Play cards from provinces');

--- a/test/server/cards/08-MotC/ChukanNobue.spec.js
+++ b/test/server/cards/08-MotC/ChukanNobue.spec.js
@@ -66,6 +66,10 @@ describe('Chukan Nobue', function() {
                 expect(this.player2).toBeAbleToSelect('upholding-authority');
                 this.upholdingAuthority = this.player2.clickCard('upholding-authority');
                 expect(this.getChatLogs(2)).toContain('player1 reveals their hand: Ornate Fan');
+                expect(this.player2).toHavePrompt('Choose a card to discard');
+                expect(this.player2).toHaveDisabledPromptButton('Ornate Fan');
+                expect(this.player2).toHavePromptButton('Don\'t discard anything');
+                this.player2.clickPrompt('Don\'t discard anything');
                 this.player1.clickPrompt('yes');
                 expect(this.player1).toHavePrompt('Air Ring');
             });


### PR DESCRIPTION
Closes #3202

I've added a cardCondition to CardMenuAction so that card buttons can be displayed but disabled (similar to the deck search).

I have also added that CardMenuAction has a legal target if any `handlers` have been added (even if all cards are invalid targets) so that you still receive the prompt.  This means that I needed to adjust Peasant's advice and also a test with Chukan Nobue and Upholding Authority.

Peasant's adivce now uses a CardSelectAction instead of CardMenuAction as it seems a more appropriate fit.  I did have to write a rather ugly cardCondition on Peasant's Advice to prevent it targeting a faceup with province with only facedown dynasty cards in it, but because the discard is optional it was not able to handle it correctly otherwise.