### PR TITLE
Optional abilities shouldn't get a pass for legal targets

### DIFF
--- a/server/game/GameActions/GameAction.ts
+++ b/server/game/GameActions/GameAction.ts
@@ -11,6 +11,7 @@ type PlayerOrRingOrCardOrToken = Player | Ring | BaseCard | StatusToken;
 
 export interface GameActionProperties {
     target?: PlayerOrRingOrCardOrToken | PlayerOrRingOrCardOrToken[];
+    optional?: boolean;
 }
 
 export class GameAction {
@@ -21,7 +22,7 @@ export class GameAction {
     name = '';
     cost = '';
     effect = '';
-    defaultProperties: GameActionProperties = {};
+    defaultProperties: GameActionProperties = { optional: false };
     getDefaultTargets: (context: AbilityContext) => any = context => this.defaultTargets(context);
 
     constructor(propertyFactory: GameActionProperties | ((context?: AbilityContext) => GameActionProperties) = {}) {
@@ -125,6 +126,11 @@ export class GameAction {
 
     isEventFullyResolved(event: Event, target: any, context: AbilityContext, additionalProperties = {}): boolean { // eslint-disable-line no-unused-vars
         return !event.cancelled && event.name === this.eventName;
+    }
+
+    isOptional(context: AbilityContext, additionalProperties = {}): boolean {
+        const { optional } = this.getProperties(context, additionalProperties);
+        return optional;
     }
 
     moveFateEventCondition(event): boolean {

--- a/server/game/GameActions/ResolveElementAction.ts
+++ b/server/game/GameActions/ResolveElementAction.ts
@@ -7,7 +7,6 @@ import { RingAction, RingActionProperties} from './RingAction';
 import { EventNames } from '../Constants';
 
 export interface ResolveElementProperties extends RingActionProperties {
-    optional?: boolean;
     physicalRing?: Ring;
     player?: Player;
 }
@@ -16,7 +15,6 @@ export class ResolveElementAction extends RingAction {
     name = 'resolveElement';
     eventName = EventNames.OnResolveRingElement;
     effect = 'resolve {0} effect';
-    defaultProperties: ResolveElementProperties = { optional: true };
     constructor(properties: ((context: AbilityContext) => ResolveElementProperties) | ResolveElementProperties) {
         super(properties);
     }

--- a/server/game/GameActions/SelectCardAction.ts
+++ b/server/game/GameActions/SelectCardAction.ts
@@ -13,7 +13,6 @@ export interface SelectCardProperties extends CardActionProperties {
     player?: Players;
     cardType?: CardTypes | CardTypes[];
     controller?: Players;
-    optional?: boolean;
     location?: Locations | Locations[];
     cardCondition?: (card: BaseCard, context: AbilityContext) => boolean;
     targets?: boolean;
@@ -57,14 +56,14 @@ export class SelectCardAction extends CardGameAction {
 
     canAffect(card: BaseCard, context: AbilityContext, additionalProperties = {}): boolean {
         let properties = this.getProperties(context, additionalProperties);
-        let player = properties.targets && context.choosingPlayerOverride || (properties.player === Players.Opponent ? context.player.opponent : context.player);
+        let player = properties.targets && context.choosingPlayerOverride || properties.player === Players.Opponent && context.player.opponent || context.player;
         return properties.selector.canTarget(card, context, player);
     }
 
     hasLegalTarget(context: AbilityContext, additionalProperties = {}): boolean {
         let properties = this.getProperties(context, additionalProperties);
-        let player = properties.targets && context.choosingPlayerOverride || (properties.player === Players.Opponent ? context.player.opponent : context.player);
-        return properties.selector.optional || properties.selector.hasEnoughTargets(context, player);
+        let player = properties.targets && context.choosingPlayerOverride || properties.player === Players.Opponent && context.player.opponent || context.player;
+        return properties.selector.hasEnoughTargets(context, player);
     }
 
     addEventsToArray(events, context: AbilityContext, additionalProperties = {}): void {

--- a/server/game/ThenAbility.js
+++ b/server/game/ThenAbility.js
@@ -23,6 +23,17 @@ class ThenAbility extends BaseAbility {
         });
     }
 
+    checkGameActionsForPotential(context) {
+        if(super.checkGameActionsForPotential(context)) {
+            return true;
+        } else if(this.gameAction.every(gameAction => gameAction.isOptional(context)) && this.properties.then) {
+            const then = typeof(this.properties.then) === 'function' ? this.properties.then(context) : this.properties.then;
+            const thenAbility = new ThenAbility(this.game, this.card, then);
+            return thenAbility.meetsRequirements(thenAbility.createContext(context.player)) === '';
+        }
+        return false;
+    }
+
     displayMessage(context) {
         if(this.properties.message) {
             let messageArgs = [context.player, context.source, context.target];

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -98,12 +98,16 @@ class BaseAbility {
             return 'cost';
         }
         if(this.targets.length === 0) {
-            if(this.gameAction.length > 0 && !this.gameAction.some(gameAction => gameAction.hasLegalTarget(context))) {
+            if(this.gameAction.length > 0 && !this.checkGameActionsForPotential(context)) {
                 return 'condition';
             }
             return '';
         }
         return this.canResolveTargets(context) ? '' : 'target';
+    }
+
+    checkGameActionsForPotential(context) {
+        return this.gameAction.some(gameAction => gameAction.hasLegalTarget(context));
     }
 
     /**

--- a/test/server/cards/07-WotW/Aranat.spec.js
+++ b/test/server/cards/07-WotW/Aranat.spec.js
@@ -21,20 +21,22 @@ describe('Aranat', function() {
                 this.shamefulDisplay = this.player2.findCardByName('shameful-display');
 
                 this.player1.clickCard(this.aranat);
-                this.player1.clickPrompt('1');
             });
 
             it('should trigger when Aranat is played', function() {
+                this.player1.clickPrompt('1');
                 expect(this.player1).toHavePrompt('Triggered Abilities');
                 expect(this.player1).toBeAbleToSelect(this.aranat);
             });
 
             it('should prompt the opponent to flip provinces', function() {
+                this.player1.clickPrompt('1');
                 this.player1.clickCard(this.aranat);
                 expect(this.player2).toHavePrompt('Aranat');
             });
 
             it('should place fate on Aranat equal to the number of facedown provinces', function() {
+                this.player1.clickPrompt('1');
                 expect(this.fertileFields.facedown).toBe(true);
                 expect(this.aranat.fate).toBe(1);
                 this.player1.clickCard(this.aranat);
@@ -46,6 +48,7 @@ describe('Aranat', function() {
             });
 
             it('should not allow revealing the SH province', function() {
+                this.player1.clickPrompt('1');
                 expect(this.fertileFields.facedown).toBe(true);
                 expect(this.shamefulDisplay.facedown).toBe(true);
                 expect(this.aranat.fate).toBe(1);
@@ -62,6 +65,7 @@ describe('Aranat', function() {
             it('should not give any fate when all provinces are revealed', function() {
                 this.shamefulDisplay.facedown = false;
                 let player2Fate = this.player2.fate;
+                this.player1.clickPrompt('1');
                 expect(this.aranat.fate).toBe(1);
                 this.player1.clickCard(this.aranat);
                 this.player2.clickCard(this.fertileFields);
@@ -78,11 +82,12 @@ describe('Aranat', function() {
             });
 
             it('should not prompt the opponent when all non-SH provinces are revealed', function() {
-                expect(this.aranat.fate).toBe(1);
                 this.fertileFields.facedown = false;
                 this.entrenchedPosition.facedown = false;
                 this.pilgrimage.facedown = false;
                 this.rallyToTheCause.facedown = false;
+                this.player1.clickPrompt('1');
+                expect(this.aranat.fate).toBe(1);
                 this.player1.clickCard(this.aranat);
                 expect(this.aranat.fate).toBe(2);
                 expect(this.player2).toHavePrompt('Play cards from provinces');


### PR DESCRIPTION
Also I added the ability to flag any game action as optional.  Note that there's no logic to back that up however (except for some actions which already support an optional property), so that will need adding in the future.