### PR TITLE
Bugfix - Feral Ningyo

### DIFF
--- a/server/game/GameActions/DelayedEffectAction.ts
+++ b/server/game/GameActions/DelayedEffectAction.ts
@@ -17,23 +17,22 @@ export class DelayedEffectAction extends CardGameAction {
     eventName = EventNames.OnEffectApplied;
     effect = 'apply a delayed effect to {0}';
 
-    defaultProperties: DelayedEffectActionProperties;
+    defaultProperties: DelayedEffectActionProperties = {
+        when: null,
+        message: null,
+        gameAction: null,
+        location: Locations.PlayArea
+    };
+
     constructor(properties: DelayedEffectActionProperties | ((context: AbilityContext) => DelayedEffectActionProperties)) {
         super(properties);
     }
 
     canAffect(card: BaseCard, context: AbilityContext, additionalProperties = {}): boolean {
         let properties = this.getProperties(context, additionalProperties) as DelayedEffectActionProperties;
-        if(properties.location) {
-            let inLocation = Array.isArray(properties.location) ? properties.location.includes(card.location) : properties.location === card.location;
-            if(!inLocation) {
-                return false;
-            }
-        }
-        else {
-            if(card.location !== Locations.PlayArea) {
-                return false;
-            }
+        let inLocation = Array.isArray(properties.location) ? properties.location.includes(card.location) : properties.location === card.location;
+        if(!inLocation) {
+            return false;
         }
         return super.canAffect(card, context);
     }

--- a/server/game/GameActions/DelayedEffectAction.ts
+++ b/server/game/GameActions/DelayedEffectAction.ts
@@ -9,6 +9,7 @@ export interface DelayedEffectActionProperties extends CardActionProperties {
     when: WhenType;
     message: string;
     gameAction: GameAction;
+    location?: Locations | Locations[];
 }
 
 export class DelayedEffectAction extends CardGameAction {
@@ -21,9 +22,18 @@ export class DelayedEffectAction extends CardGameAction {
         super(properties);
     }
 
-    canAffect(card: BaseCard, context: AbilityContext): boolean {
-        if(card.location !== Locations.PlayArea) {
-            return false;
+    canAffect(card: BaseCard, context: AbilityContext, additionalProperties = {}): boolean {
+        let properties = this.getProperties(context, additionalProperties) as DelayedEffectActionProperties;
+        if(properties.location) {
+            let inLocation = Array.isArray(properties.location) ? properties.location.includes(card.location) : properties.location === card.location;
+            if(!inLocation) {
+                return false;
+            }
+        }
+        else {
+            if(card.location !== Locations.PlayArea) {
+                return false;
+            }
         }
         return super.canAffect(card, context);
     }

--- a/server/game/cards/04.2-TL/FeralNingyo.js
+++ b/server/game/cards/04.2-TL/FeralNingyo.js
@@ -10,7 +10,7 @@ class FeralNingyo extends DrawCard {
             location: [Locations.Hand, Locations.PlayArea],
             effect: '{1}return {0} to the deck at the end of the conflict',
             effectArgs: context => [context.source.location !== Locations.PlayArea ? ['put {0} into play into the conflict and ', context.source] : ''],
-            gameAction: AbilityDsl.actions.multiple([
+            gameAction: AbilityDsl.actions.sequential([
                 AbilityDsl.actions.putIntoConflict(context => ({
                     target: context.source
                 })),

--- a/server/game/cards/04.2-TL/FeralNingyo.js
+++ b/server/game/cards/04.2-TL/FeralNingyo.js
@@ -1,22 +1,29 @@
 const DrawCard = require('../../drawcard.js');
 const { Locations } = require('../../Constants');
+const AbilityDsl = require('../../abilitydsl');
 
 class FeralNingyo extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.action({
             title: 'Put into play',
             condition: () => this.game.isDuringConflict('water'),
-            location: Locations.Hand,
-            gameAction: ability.actions.putIntoConflict(),
-            then: () => ({
-                gameAction: ability.actions.delayedEffect({
+            location: [Locations.Hand, Locations.PlayArea],
+            effect: '{1}return {0} to the deck at the end of the conflict',
+            effectArgs: context => [context.source.location !== Locations.PlayArea ? ['put {0} into play into the conflict and ', context.source] : ''],
+            gameAction: AbilityDsl.actions.multiple([
+                AbilityDsl.actions.putIntoConflict(context => ({
+                    target: context.source
+                })),
+                AbilityDsl.actions.delayedEffect(context => ({
+                    target: context.source,
+                    location: [Locations.Hand, Locations.PlayArea],
                     when: {
                         onConflictFinished: () => true
                     },
-                    message: '{0} returns to the deck and shuffles due to it\'s effect',
-                    gameAction: ability.actions.returnToDeck({ shuffle: true })
-                })
-            })
+                    message: '{0} returns to the deck and shuffles due to its delayed effect',
+                    gameAction: AbilityDsl.actions.returnToDeck({ shuffle: true })
+                }))
+            ])
         });
     }
 }

--- a/server/game/gamechat.js
+++ b/server/game/gamechat.js
@@ -41,6 +41,9 @@ class GameChat {
                     if(arg.message) {
                         return output.concat(arg.message);
                     } else if(Array.isArray(arg)) {
+                        if(typeof arg[0] === 'string' && arg[0].includes('{')) {
+                            return output.concat(this.formatMessage(arg[0], arg.slice(1)));
+                        }
                         return output.concat(this.formatArray(arg));
                     } else if(arg.getShortSummary) {
                         return output.concat(arg.getShortSummary());

--- a/test/server/cards/04.2-TL/FeralNingyo.spec.js
+++ b/test/server/cards/04.2-TL/FeralNingyo.spec.js
@@ -89,6 +89,7 @@ describe('Feral Ningyo', function () {
                 it('should put it into play', function () {
                     this.player1.clickPrompt('Put into play');
                     expect(this.feral.location).toBe('play area');
+                    expect(this.getChatLogs(3)).toContain('player1 uses Feral Ningyo to put Feral Ningyo into play into the conflict and return Feral Ningyo to the deck at the end of the conflict');
                 });
 
                 it('should return to it the conflict deck at the end of the conflict', function () {
@@ -97,6 +98,8 @@ describe('Feral Ningyo', function () {
                     this.player1.clickPrompt('No');
                     this.player1.clickPrompt('Don\'t resolve');
                     expect(this.feral.location).toBe('conflict deck');
+                    expect(this.getChatLogs(2)).toContain('Feral Ningyo returns to the deck and shuffles due to its delayed effect');
+                    expect(this.getChatLogs(1)).toContain('player1 is shuffling their conflict deck');
                 });
 
                 it('should return to it the conflict deck at the end of the conflict even with a card attached', function () {
@@ -117,6 +120,23 @@ describe('Feral Ningyo', function () {
                     this.player1.clickPrompt('No');
                     this.player1.clickPrompt('Don\'t resolve');
                     expect(this.game.emitEvent).toHaveBeenCalledWith('onDeckShuffled', jasmine.anything());
+                });
+
+                it('should be triggerable if played from hand and then triggered in play', function() {
+                    this.player1.clickPrompt('Play this character');
+                    this.player1.clickPrompt('0');
+                    this.player1.clickPrompt('Conflict');
+                    this.player2.pass();
+                    expect(this.player1).toHavePrompt('Conflict Action Window');
+                    this.player1.clickCard(this.feral);
+                    expect(this.player2).toHavePrompt('Conflict Action Window');
+                    expect(this.getChatLogs(3)).toContain('player1 uses Feral Ningyo to return Feral Ningyo to the deck at the end of the conflict');
+                    this.noMoreActions();
+                    this.player1.clickPrompt('No');
+                    this.player1.clickPrompt('Don\'t resolve');
+                    expect(this.feral.location).toBe('conflict deck');
+                    expect(this.getChatLogs(2)).toContain('Feral Ningyo returns to the deck and shuffles due to its delayed effect');
+                    expect(this.getChatLogs(1)).toContain('player1 is shuffling their conflict deck');
                 });
             });
         });


### PR DESCRIPTION
Allow Feral Ningyo to be triggerable from play

Used the nested chat message commit as well to give a better chat message and needed to add `location:` to `DelayedEffectAction` in order to be able to affect Feral Ningyo when in hand.

This could give rise to a strange interaction if there is ever a "cannot put cards in to play into a conflict" or similar effect where Feral Ningyo would be triggerable from hand and not come into play but just setup a delayed effect.  Although currently the returnToDeck action will not return to deck if the card is not in play, so a bit of a strange one to possibly watch out for in the future.