### PR TITLE
Fix build error of facedown on BaseCard

### DIFF
--- a/server/game/basecard.ts
+++ b/server/game/basecard.ts
@@ -23,6 +23,7 @@ class BaseCard extends EffectSource {
     printedName: string;
     inConflict: boolean = false;
     type: CardTypes;
+    facedown: boolean;
     
     tokens: object = {};
     menu: _.Underscore<any> = _([]);


### PR DESCRIPTION
```
server/game/basecard.ts:259:18 - error TS2339: Property 'facedown' does not exist on type 'BaseCard'.
259             this.facedown = false;
                     ~~~~~~~~
```