### PR TITLE
Bugfix - improved chat messages for dispatch

### DIFF
--- a/server/game/cards/04.5-AaN/Dispatch.js
+++ b/server/game/cards/04.5-AaN/Dispatch.js
@@ -14,8 +14,16 @@ class Dispatch extends DrawCard {
                     condition: (context, properties) => properties.target[0].inConflict,
                     trueGameAction: AbilityDsl.actions.sendHome(),
                     falseGameAction: AbilityDsl.actions.moveToConflict()
-                })
-            })
+                }),
+                message: '{0} chooses to {3} {1} {2}',
+                messageArgs: (card, player) => [
+                    player,
+                    card,
+                    card.inConflict ? 'home' : 'into the conflict',
+                    card.inConflict ? 'send' : 'move'
+                ]
+            }),
+            effect: 'choose a unicorn character they control into a conflict or home'
         });
     }
 }

--- a/server/game/cards/04.5-AaN/Dispatch.js
+++ b/server/game/cards/04.5-AaN/Dispatch.js
@@ -23,7 +23,7 @@ class Dispatch extends DrawCard {
                     card.inConflict ? 'send' : 'move'
                 ]
             }),
-            effect: 'choose a unicorn character they control into a conflict or home'
+            effect: 'choose a unicorn character they control to move into a conflict or home'
         });
     }
 }

--- a/test/server/cards/04.5-AaN/Dispatch.spec.js
+++ b/test/server/cards/04.5-AaN/Dispatch.spec.js
@@ -27,7 +27,7 @@ describe('Dispatch', function() {
                 expect(this.player1).not.toBeAbleToSelect('miya-mystic');
                 expect(this.player1).toBeAbleToSelect('moto-youth');
                 expect(this.player1).toBeAbleToSelect('moto-horde');
-                expect(this.getChatLogs(1)).toContain('player1 plays Dispatch to choose a unicorn character they control into a conflict or home');
+                expect(this.getChatLogs(1)).toContain('player1 plays Dispatch to choose a unicorn character they control to move into a conflict or home');
             });
 
             it('should correctly move character in the conflict', function() {

--- a/test/server/cards/04.5-AaN/Dispatch.spec.js
+++ b/test/server/cards/04.5-AaN/Dispatch.spec.js
@@ -27,6 +27,7 @@ describe('Dispatch', function() {
                 expect(this.player1).not.toBeAbleToSelect('miya-mystic');
                 expect(this.player1).toBeAbleToSelect('moto-youth');
                 expect(this.player1).toBeAbleToSelect('moto-horde');
+                expect(this.getChatLogs(1)).toContain('player1 plays Dispatch to choose a unicorn character they control into a conflict or home');
             });
 
             it('should correctly move character in the conflict', function() {
@@ -39,6 +40,7 @@ describe('Dispatch', function() {
                 this.player1.clickCard('dispatch');
                 this.player1.clickCard('moto-horde');
                 expect(this.horde.isParticipating()).toBe(true);
+                expect(this.getChatLogs(3)).toContain('player1 chooses to move Moto Horde into the conflict');
             });
 
             it('should correctly send character home', function() {
@@ -51,6 +53,7 @@ describe('Dispatch', function() {
                 this.player1.clickCard('dispatch');
                 this.player1.clickCard('moto-horde');
                 expect(this.horde.isParticipating()).toBe(false);
+                expect(this.getChatLogs(3)).toContain('player1 chooses to send Moto Horde home');
             });
         });
     });


### PR DESCRIPTION
Dispatch currently only leaves the chat message
```
'player1 plays Dispatch to choose a target for Dispatch'
```
this fixes that to something like:
```
'player1 plays Dispatch to choose a unicorn character they control to move into a conflict or home',
'player1 chooses to move Moto Horde home'
```