### PR TITLE
Byoyomi - fixes and additional options

### DIFF
--- a/client/NewGame.jsx
+++ b/client/NewGame.jsx
@@ -8,7 +8,7 @@ const defaultTime = {
     timer: '60',
     chess: '40',
     hourglass: '15',
-    byoyomi: '10'
+    byoyomi: '0'
 };
 
 class InnerNewGame extends React.Component {
@@ -29,6 +29,8 @@ class InnerNewGame extends React.Component {
             clocks: false,
             selectedClockType: 'timer',
             clockTimer: 60,
+            byoyomiPeriods: 5,
+            byoyomiTimePeriod: 30,
             selectedGameType: 'casual',
             password: ''
         };
@@ -69,7 +71,9 @@ class InnerNewGame extends React.Component {
 
         let clocks = {
             type: this.state.clocks ? this.state.selectedClockType : 'none',
-            time: this.state.clocks ? this.state.clockTimer : 0
+            time: this.state.clocks ? this.state.clockTimer : 0,
+            periods: this.state.clocks ? this.state.byoyomiPeriods : 0,
+            timePeriod: this.state.clocks ? this.state.byoyomiTimePeriod : 0
         };
 
         this.props.socket.emit('newgame', {
@@ -126,10 +130,20 @@ class InnerNewGame extends React.Component {
                 </div>
                 <div className='row'>
                     <div className='col-sm-8'>
-                        <label>Clock Timer</label>
+                        <label>Main Time (Minutes)</label>
                         <input className='form-control' value={ this.state.clockTimer } onChange={ event => this.setState({ clockTimer: event.target.value.replace(/\D/,'') }) }/>
                     </div>
                 </div>
+                { this.state.selectedClockType === 'byoyomi' &&
+                    <div className='row'>
+                        <div className='col-sm-8'>
+                            <label>Number of Byoyomi Periods</label>
+                            <input className='form-control' value={ this.state.byoyomiPeriods } onChange={ event => this.setState({ byoyomiPeriods: event.target.value.replace(/\D/, '') }) }/>
+                            <label>Byoyomi Time Period (Seconds)</label>
+                            <input className='form-control' value={ this.state.byoyomiTimePeriod } onChange={ event => this.setState({ byoyomiTimePeriod: event.target.value.replace(/\D/, '') }) }/>
+                        </div>
+                    </div>
+                }
             </div>
         );
     }

--- a/client/PendingGame.jsx
+++ b/client/PendingGame.jsx
@@ -173,6 +173,17 @@ class InnerPendingGame extends React.Component {
         this.props.zoomCard(card);
     }
 
+    getClock() {
+        let game = this.props.currentGame;
+        if(!game.clocks || game.clocks.type === 'none') {
+            return;
+        }
+        if(game.clocks.type === 'byoyomi') {
+            return `Clock: ${game.clocks.time} mins + ${game.clocks.periods} x ${game.clocks.timePeriod} secs (byoyomi)`;
+        }
+        return 'Clock: ' + game.clocks.time + ' mins (' + (game.clocks.type) + ')';
+    }
+
     render() {
         if(this.props.currentGame && this.props.currentGame.started) {
             return <div>Loading game in progress, please wait...</div>;
@@ -240,7 +251,7 @@ class InnerPendingGame extends React.Component {
                                 { game.allowSpectators ? 'Spectators can chat: ' + (game.spectatorSquelch ? 'No' : 'Yes') : null }
                             </div>
                             <div>
-                                { game.clocks && game.clocks.type !== 'none' ? 'Clock: ' + game.clocks.time + ' mins (' + (game.clocks.type) + ')' : null }
+                                { this.getClock() }
                             </div>
                         </div>
                     </div>

--- a/server/game/Clocks/Byoyomi.js
+++ b/server/game/Clocks/Byoyomi.js
@@ -1,8 +1,18 @@
 const ChessClock = require('./ChessClock');
 
 class Byoyomi extends ChessClock {
+    constructor(player, time, periods, timePeriod) {
+        super(player, time);
+        this.periods = periods;
+        this.timePeriod = timePeriod;
+        this.timeLeft = time + (periods * timePeriod);
+    }
+
     reset() {
-        this.timeLeft = Math.ceil((this.timeLeft) / 30) * 30;
+        if(this.timeLeft > 0 && this.timeLeft < this.periods * this.timePeriod) {
+            this.periods = Math.ceil(this.timeLeft / this.timePeriod);
+            this.timeLeft = this.periods * this.timePeriod;
+        }
     }
 }
 

--- a/server/game/Clocks/Byoyomi.js
+++ b/server/game/Clocks/Byoyomi.js
@@ -1,8 +1,8 @@
 const ChessClock = require('./ChessClock');
 
 class Byoyomi extends ChessClock {
-    updateTimeLeft(secs) {
-        super.updateTimeLeft(secs - (secs % 30));
+    reset() {
+        this.timeLeft = Math.ceil((this.timeLeft) / 30) * 30;
     }
 }
 

--- a/server/game/Clocks/Clock.js
+++ b/server/game/Clocks/Clock.js
@@ -1,6 +1,7 @@
 class Clock {
     constructor(player, time) {
         this.player = player;
+        this.mainTime = time;
         this.timeLeft = time;
         this.mode = 'off';
         this.timerStart = 0;

--- a/server/game/Clocks/Clock.js
+++ b/server/game/Clocks/Clock.js
@@ -39,6 +39,9 @@ class Clock {
         }
     }
 
+    reset() {
+    }
+
     opponentStart() {
         this.timerStart = Date.now();
         this.updateStateId();

--- a/server/game/Clocks/ClockSelector.js
+++ b/server/game/Clocks/ClockSelector.js
@@ -9,18 +9,18 @@ const typeToClock = {
     timer: (player, time) => new Timer(player, time),
     chess: (player, time) => new ChessClock(player, time),
     hourglass: (player, time) => new Hourglass(player, time),
-    byoyomi: (player, time) => new Byoyomi(player, time)
+    byoyomi: (player, time, periods, timePeriod) => new Byoyomi(player, time, periods, timePeriod)
 };
 
 class ClockSelector {
-    static for(player, details = { type: 'none', time: 0 }) {
+    static for(player, details = { type: 'none', time: 0, periods: 0, timePeriod: 0 }) {
         let factory = typeToClock[details.type];
 
         if(!factory) {
             throw new Error(`Unknown clock selector type of ${details.type}`);
         }
 
-        return factory(player, details.time * 60);
+        return factory(player, details.time * 60, details.periods, details.timePeriod);
     }
 }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -308,6 +308,10 @@ class Game extends EventEmitter {
         _.each(this.getPlayers(), player => player.stopClock());
     }
 
+    resetClocks() {
+        _.each(this.getPlayers(), player => player.resetClock());
+    }
+
     /**
      * This function is called from the client whenever a card is clicked
      * @param {String} sourcePlayer - name of the clicking player

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -15,6 +15,7 @@ class UiPrompt extends BaseStep {
 
     complete() {
         this.completed = true;
+        this.game.resetClocks();
     }
 
     setPrompt() {
@@ -24,6 +25,7 @@ class UiPrompt extends BaseStep {
                 player.startClock();
             } else {
                 player.setPrompt(this.waitingPrompt());
+                player.resetClock();
             }
         });
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -101,6 +101,10 @@ class Player extends GameObject {
         this.clock.stop();
     }
 
+    resetClock() {
+        this.clock.reset();
+    }
+
     /**
      * Checks whether a card with a uuid matching the passed card is in the passed _(Array)
      * @param list _(Array)

--- a/test/server/gamesteps/initiateconflictprompt.spec.js
+++ b/test/server/gamesteps/initiateconflictprompt.spec.js
@@ -2,7 +2,7 @@ const InitateConflictPrompt = require('../../../build/server/game/gamesteps/conf
 
 describe('InitateConflictPrompt: ', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'raiseEvent', 'promptWithHandlerMenu', 'getFrameworkContext']);
+        this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'raiseEvent', 'promptWithHandlerMenu', 'getFrameworkContext', 'resetClocks']);
         this.fireRing = { element: 'fire' };
         this.gameSpy.rings = { fire: this.fireRing };
         this.playerSpy = jasmine.createSpyObj('player', ['keep', 'mulligan', 'getLegalConflictTypes', 'hasLegalConflictDeclaration']);

--- a/test/server/gamesteps/menuprompt.spec.js
+++ b/test/server/gamesteps/menuprompt.spec.js
@@ -3,7 +3,7 @@ const Player = require('../../../build/server/game/player.js');
 
 describe('the MenuPrompt', function() {
     beforeEach(function() {
-        var game = new jasmine.createSpyObj('game', ['playerDecked', 'emitEvent', 'addMessage', 'getOtherPlayer']);
+        var game = new jasmine.createSpyObj('game', ['playerDecked', 'emitEvent', 'addMessage', 'getOtherPlayer', 'resetClocks']);
 
         this.player = new Player('1', { username: 'Player 1', settings: {} }, true, game);
         this.player.initialise();

--- a/test/server/gamesteps/playerorderprompt.spec.js
+++ b/test/server/gamesteps/playerorderprompt.spec.js
@@ -6,8 +6,8 @@ describe('the PlayerOrderPrompt', function() {
         this.waitingPrompt = { active: false };
 
         this.game = jasmine.createSpyObj('game', ['getPlayers', 'getPlayersInFirstPlayerOrder']);
-        this.player1 = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock']);
-        this.player2 = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock']);
+        this.player1 = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock', 'resetClock']);
+        this.player2 = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock', 'resetClock']);
 
         this.game.getPlayers.and.returnValue([this.player1, this.player2]);
         this.game.getPlayersInFirstPlayerOrder.and.returnValue([this.player2, this.player1]);

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -12,12 +12,12 @@ describe('the SelectCardPrompt', function() {
 
     beforeEach(function() {
 
-        this.game = jasmine.createSpyObj('game', ['getPlayers', 'getCurrentAbilityContext']);
+        this.game = jasmine.createSpyObj('game', ['getPlayers', 'getCurrentAbilityContext', 'resetClocks']);
         this.game.getCurrentAbilityContext.and.returnValue({ source: 'framework', card: null, stage: 'framework' });
 
-        this.player = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt', 'clearSelectableCards', 'clearSelectedCards', 'setSelectableCards', 'setSelectedCards', 'clearSelectableRings', 'startClock', 'stopClock']);
+        this.player = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt', 'clearSelectableCards', 'clearSelectedCards', 'setSelectableCards', 'setSelectedCards', 'clearSelectableRings', 'startClock', 'stopClock', 'resetClock']);
         this.player.cardsInPlay = _([]);
-        this.otherPlayer = jasmine.createSpyObj('player2', ['setPrompt', 'cancelPrompt', 'clearSelectableCards', 'clearSelectedCards', 'setSelectableCards', 'setSelectedCards', 'startClock', 'stopClock']);
+        this.otherPlayer = jasmine.createSpyObj('player2', ['setPrompt', 'cancelPrompt', 'clearSelectableCards', 'clearSelectedCards', 'setSelectableCards', 'setSelectedCards', 'startClock', 'stopClock', 'resetClock']);
         this.card = createCardSpy({ controller: this.player });
 
 

--- a/test/server/gamesteps/uiprompt.spec.js
+++ b/test/server/gamesteps/uiprompt.spec.js
@@ -2,8 +2,8 @@ const UiPrompt = require('../../../build/server/game/gamesteps/uiprompt.js');
 
 describe('the UiPrompt', function() {
     beforeEach(function() {
-        this.player1 = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock']);
-        this.player2 = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock']);
+        this.player1 = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock', 'resetClock']);
+        this.player2 = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock', 'resetClock']);
 
         this.game = jasmine.createSpyObj('game', ['getPlayers']);
         this.game.getPlayers.and.returnValue([this.player1, this.player2]);


### PR DESCRIPTION
Fixes the byoyomi clock to work.

Now resets the clock when either:
- the current gamestep completes (resets both player's clocks) or 
- the player is presented with a waiting prompt (resets the waiting player's clock)

Now allows you to specify a main timer and a number of byoyomi periods and time period (10 mins + 3 x 30 secs for example).