### PR TITLE
BoB - Hiruma Yoshino

### DIFF
--- a/server/game/Constants.ts
+++ b/server/game/Constants.ts
@@ -40,6 +40,7 @@ export enum EffectNames {
     CannotHaveOtherRestrictedAttachments = 'cannotHaveOtherRestrictedAttachments',
     CannotParticipateAsAttacker = 'cannotParticipateAsAttacker',
     CannotParticipateAsDefender = 'cannotParticipateAsDefender',
+    ChangeSkillFunction = 'changeSkillFunction',
     CopyCharacter = 'copyCharacter',
     CustomEffect = 'customEffect',
     DelayedEffect = 'delayedEffect',

--- a/server/game/Constants.ts
+++ b/server/game/Constants.ts
@@ -35,6 +35,7 @@ export enum EffectNames {
     CannotApplyLastingEffects = 'cannotApplyLastingEffects',
     CannotBeAttacked = 'cannotBeAttacked',
     CannotBidInDuels = 'cannotBidInDuels',
+    CannotContribute = 'cannotContribute',
     CannotHaveConflictsDeclaredOfType = 'cannotHaveConflictsDeclaredOfType',
     CannotHaveOtherRestrictedAttachments = 'cannotHaveOtherRestrictedAttachments',
     CannotParticipateAsAttacker = 'cannotParticipateAsAttacker',

--- a/server/game/Constants.ts
+++ b/server/game/Constants.ts
@@ -40,7 +40,7 @@ export enum EffectNames {
     CannotHaveOtherRestrictedAttachments = 'cannotHaveOtherRestrictedAttachments',
     CannotParticipateAsAttacker = 'cannotParticipateAsAttacker',
     CannotParticipateAsDefender = 'cannotParticipateAsDefender',
-    ChangeSkillFunction = 'changeSkillFunction',
+    ChangeContributionFunction = 'changeContributionFunction',
     CopyCharacter = 'copyCharacter',
     CustomEffect = 'customEffect',
     DelayedEffect = 'delayedEffect',

--- a/server/game/Effects/DynamicEffect.js
+++ b/server/game/Effects/DynamicEffect.js
@@ -15,6 +15,9 @@ class DynamicEffect extends StaticEffect {
     recalculate(target) {
         let oldValue = this.getValue(target);
         let newValue = this.setValue(target, this.calculate(target, this.context));
+        if(typeof oldValue === 'function' && typeof newValue === 'function') {
+            return oldValue.toString() !== newValue.toString();
+        }
         if(Array.isArray(oldValue) && Array.isArray(newValue)) {
             return JSON.stringify(oldValue) !== JSON.stringify(newValue);
         }

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -146,7 +146,7 @@ export interface PersistentEffectProps {
     condition?: (context: AbilityContext) => boolean;
     match?: (card: BaseCard, context?: AbilityContext) => boolean;
     targetController?: Players;
-    targetLocation?: Locations | Locations[];
+    targetLocation?: Locations;
     effect: Function | Function[];
 };
 

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -146,7 +146,7 @@ export interface PersistentEffectProps {
     condition?: (context: AbilityContext) => boolean;
     match?: (card: BaseCard, context?: AbilityContext) => boolean;
     targetController?: Players;
-    targetLocation?: Locations;
+    targetLocation?: Locations | Locations[];
     effect: Function | Function[];
 };
 

--- a/server/game/basecard.ts
+++ b/server/game/basecard.ts
@@ -240,7 +240,7 @@ class BaseCard extends EffectSource {
             'play area': [Locations.PlayArea],
             'province': [Locations.ProvinceOne, Locations.ProvinceTwo, Locations.ProvinceThree, Locations.ProvinceFour, Locations.StrongholdProvince]
         };
-        if(from === Locations.PlayArea || this.type === CardTypes.Holding && activeLocations[Locations.Provinces].includes(from) && !activeLocations[Locations.Provinces].includes(to)) {
+        if(!activeLocations[Locations.Provinces].includes(from) || !activeLocations[Locations.Provinces].includes(to)) {
             this.removeLastingEffects();
         }
         _.each(this.persistentEffects, effect => {

--- a/server/game/cards/02.1-ToA/SwiftMagistrate.js
+++ b/server/game/cards/02.1-ToA/SwiftMagistrate.js
@@ -1,13 +1,13 @@
 const DrawCard = require('../../drawcard.js');
-const { Players } = require('../../Constants');
+const AbilityDsl = require('../../abilitydsl.js');
 
 class SwiftMagistrate extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.persistentEffect({
             condition: context => context.source.isAttacking(),
-            match: (card, context) => card.fate > 0 && card !== context.source,
-            targetController: Players.Any,
-            effect: ability.effects.cardCannot('countForResolution')
+            effect: AbilityDsl.effects.cannotContribute((conflict, context) => {
+                return card => card.fate > 0 && card !== context.source;
+            })
         });
     }
 }

--- a/server/game/cards/02.2-FHaG/StoicMagistrate.js
+++ b/server/game/cards/02.2-FHaG/StoicMagistrate.js
@@ -1,13 +1,13 @@
 const DrawCard = require('../../drawcard.js');
-const { Players } = require('../../Constants');
+const AbilityDsl = require('../../abilitydsl.js');
 
 class StoicMagistrate extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.persistentEffect({
             condition: context => context.source.isDefending(),
-            match: card => card.costLessThan(3),
-            targetController: Players.Any,
-            effect: ability.effects.cardCannot('countForResolution')
+            effect: AbilityDsl.effects.cannotContribute(() => {
+                return card => card.costLessThan(3);
+            })
         });
     }
 }

--- a/server/game/cards/02.3-ItFC/EnigmaticMagistrate.js
+++ b/server/game/cards/02.3-ItFC/EnigmaticMagistrate.js
@@ -1,13 +1,13 @@
 const DrawCard = require('../../drawcard.js');
-const { Players } = require('../../Constants');
+const AbilityDsl = require('../../abilitydsl');
 
 class EnigmaticMagistrate extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.persistentEffect({
             condition: context => context.source.isAttacking(),
-            match: card => card.getCost() === 0 || card.getCost() && card.getCost() % 2 === 0,
-            targetController: Players.Any,
-            effect: ability.effects.cardCannot('countForResolution')
+            effect: AbilityDsl.effects.cannotContribute(() => {
+                return card => card.getCost() === 0 || card.getCost() && card.getCost() % 2 === 0;
+            })
         });
     }
 }

--- a/server/game/cards/02.4-TCT/HaughtyMagistrate.js
+++ b/server/game/cards/02.4-TCT/HaughtyMagistrate.js
@@ -1,14 +1,13 @@
 const DrawCard = require('../../drawcard.js');
-const { Players } = require('../../Constants');
+const AbilityDsl = require('../../abilitydsl');
 
 class HaughtyMagistrate extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.persistentEffect({
             condition: context => context.source.isAttacking(),
-            match: (card, context) =>
-                card.getGlory() < context.source.getGlory() && card !== context.source,
-            targetController: Players.Any,
-            effect: ability.effects.cardCannot('countForResolution')
+            effect: AbilityDsl.effects.cannotContribute((conflict, context) => {
+                return card => card.getGlory() < context.source.getGlory() && card !== context.source;
+            })
         });
     }
 }

--- a/server/game/cards/02.4-TCT/ImplacableMagistrate.js
+++ b/server/game/cards/02.4-TCT/ImplacableMagistrate.js
@@ -1,13 +1,13 @@
 const DrawCard = require('../../drawcard.js');
-const { Players } = require('../../Constants');
+const AbilityDsl = require('../../abilitydsl');
 
 class ImplacableMagistrate extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.persistentEffect({
             condition: context => context.source.isAttacking(),
-            match: (card, context) => !card.isHonored && card !== context.source,
-            targetController: Players.Any,
-            effect: ability.effects.cardCannot('countForResolution')
+            effect: AbilityDsl.effects.cannotContribute((conflict, context) => {
+                return card => !card.isHonored && card !== context.source;
+            })
         });
     }
 }

--- a/server/game/cards/02.5-FHNS/CunningMagistrate.js
+++ b/server/game/cards/02.5-FHNS/CunningMagistrate.js
@@ -1,13 +1,13 @@
 const DrawCard = require('../../drawcard.js');
-const { Players } = require('../../Constants');
+const AbilityDsl = require('../../abilitydsl');
 
 class CunningMagistrate extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.persistentEffect({
             condition: context => context.source.isParticipating(),
-            match: (card, context) => card.isDishonored && card !== context.source,
-            targetController: Players.Any,
-            effect: ability.effects.cardCannot('countForResolution')
+            effect: AbilityDsl.effects.cannotContribute((conflict, context) => {
+                return card => card.isDishonored && card !== context.source;
+            })
         });
     }
 }

--- a/server/game/cards/02.6-MotE/SilvertonguedMagistrate.js
+++ b/server/game/cards/02.6-MotE/SilvertonguedMagistrate.js
@@ -1,13 +1,13 @@
 const DrawCard = require('../../drawcard.js');
-const { Players } = require('../../Constants');
+const AbilityDsl = require('../../abilitydsl.js');
 
 class SilverTonguedMagistrate extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.persistentEffect({
             condition: context => context.source.isAttacking(),
-            match: (card, context) => card.fate === 0 && card !== context.source,
-            targetController: Players.Any,
-            effect: ability.effects.cardCannot('countForResolution')
+            effect: AbilityDsl.effects.cannotContribute((conflict, context) => {
+                return card => card.fate === 0 && card !== context.source;
+            })
         });
     }
 }

--- a/server/game/cards/03-DotV/KaitoKosori.js
+++ b/server/game/cards/03-DotV/KaitoKosori.js
@@ -1,12 +1,13 @@
 const DrawCard = require('../../drawcard.js');
+const AbilityDsl = require('../../abilitydsl');
 
 class KaitoKosori extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.persistentEffect({
             condition: context =>
                 context.player.cardsInPlay.any(card => card.isParticipating()) &&
                 this.game.currentConflict.hasElement('air') && !context.source.isParticipating(),
-            effect: ability.effects.contributeToConflict((conflict, context) => context.source)
+            effect: AbilityDsl.effects.contributeToConflict((card, context) => context.player)
         });
     }
 }

--- a/server/game/cards/06-CotE/HumbleMagistrate.js
+++ b/server/game/cards/06-CotE/HumbleMagistrate.js
@@ -1,14 +1,13 @@
 const DrawCard = require('../../drawcard.js');
-const { Players } = require('../../Constants');
 const AbilityDsl = require('../../abilitydsl.js');
 
 class HumbleMagistrate extends DrawCard {
     setupCardAbilities() {
         this.persistentEffect({
             condition: context => context.source.isAttacking(),
-            match: (card) => card.printedCost >= 4,
-            targetController: Players.Any,
-            effect: AbilityDsl.effects.cardCannot('countForResolution')
+            effect: AbilityDsl.effects.cannotContribute(() => {
+                return card => card.printedCost >= 4;
+            })
         });
     }
 }

--- a/server/game/cards/09.2-BoB/HirumaYoshino.js
+++ b/server/game/cards/09.2-BoB/HirumaYoshino.js
@@ -1,0 +1,28 @@
+const DrawCard = require('../../drawcard.js');
+const { Locations, CardTypes } = require('../../Constants');
+const AbilityDsl = require('../../abilitydsl.js');
+
+class HirumaYoshino extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Contribute printed military skill',
+            condition: context => context.game.isDuringConflict('military') && context.source.isParticipating(),
+            target: {
+                cardType: CardTypes.Character,
+                location: Locations.Provinces,
+                cardCondition: card => card.location === this.game.currentConflict.conflictProvince.location &&
+                    card.controller === this.game.currentConflict.conflictProvince.controller &&
+                    card.printedMilitarySkill > 0,
+                gameAction: AbilityDsl.actions.playerLastingEffect(context => ({
+                    effect: AbilityDsl.effects.changePlayerSkillModifier(context.target.printedMilitarySkill)
+                }))
+            },
+            effect: 'contribute {0}\'s printed {1} skill of {2} to their side of the conflict',
+            effectArgs: context => ['military', context.target.printedMilitarySkill]
+        });
+    }
+}
+
+HirumaYoshino.id = 'hiruma-yoshino';
+
+module.exports = HirumaYoshino;

--- a/server/game/cards/09.2-BoB/HirumaYoshino.js
+++ b/server/game/cards/09.2-BoB/HirumaYoshino.js
@@ -13,9 +13,11 @@ class HirumaYoshino extends DrawCard {
                 cardCondition: card => card.location === this.game.currentConflict.conflictProvince.location &&
                     card.controller === this.game.currentConflict.conflictProvince.controller &&
                     card.printedMilitarySkill > 0,
-                gameAction: AbilityDsl.actions.playerLastingEffect(context => ({
-                    effect: AbilityDsl.effects.changePlayerSkillModifier(context.target.printedMilitarySkill)
-                }))
+                gameAction: AbilityDsl.actions.cardLastingEffect({
+                    targetLocation: Locations.Provinces,
+                    condition: context => context.game.isDuringConflict('military'),
+                    effect: AbilityDsl.effects.contributeToConflict((card, context) => context.player)
+                })
             },
             effect: 'contribute {0}\'s printed {1} skill of {2} to their side of the conflict',
             effectArgs: context => ['military', context.target.printedMilitarySkill]

--- a/server/game/cards/09.2-BoB/HirumaYoshino.js
+++ b/server/game/cards/09.2-BoB/HirumaYoshino.js
@@ -17,7 +17,7 @@ class HirumaYoshino extends DrawCard {
                     targetLocation: Locations.Provinces,
                     effect: [
                         AbilityDsl.effects.contributeToConflict((card, context) => context.player),
-                        AbilityDsl.effects.changeSkillFunction(card => card.printedMilitarySkill)
+                        AbilityDsl.effects.changeContributionFunction(card => card.printedMilitarySkill)
                     ]
                 })
             },

--- a/server/game/cards/09.2-BoB/HirumaYoshino.js
+++ b/server/game/cards/09.2-BoB/HirumaYoshino.js
@@ -15,8 +15,10 @@ class HirumaYoshino extends DrawCard {
                     card.printedMilitarySkill > 0,
                 gameAction: AbilityDsl.actions.cardLastingEffect({
                     targetLocation: Locations.Provinces,
-                    condition: context => context.game.isDuringConflict('military'),
-                    effect: AbilityDsl.effects.contributeToConflict((card, context) => context.player)
+                    effect: [
+                        AbilityDsl.effects.contributeToConflict((card, context) => context.player),
+                        AbilityDsl.effects.changeSkillFunction(card => card.printedMilitarySkill)
+                    ]
                 })
             },
             effect: 'contribute {0}\'s printed {1} skill of {2} to their side of the conflict',

--- a/server/game/conflict.js
+++ b/server/game/conflict.js
@@ -269,8 +269,13 @@ class Conflict extends GameObject {
 
     calculateSkillFor(cards) {
         let skillFunction = this.mostRecentEffect(EffectNames.ChangeConflictSkillFunction) || (card => card.getSkill(this.conflictType));
+        let cannotContributeFunctions = this.getEffects(EffectNames.CannotContribute);
         return cards.reduce((sum, card) => {
-            if(card.bowed || !card.allowGameAction('countForResolution')) {
+            let cannotContribute = card.bowed;
+            if(!cannotContribute) {
+                cannotContribute = cannotContributeFunctions.some(func => func(card));
+            }
+            if(cannotContribute) {
                 return sum;
             }
             return sum + skillFunction(card);

--- a/server/game/conflict.js
+++ b/server/game/conflict.js
@@ -2,7 +2,7 @@ const _ = require('underscore');
 const GameObject = require('./GameObject');
 const Player = require('./player.js');
 const Settings = require('../settings.js');
-const { EffectNames, EventNames } = require('./Constants');
+const { CardTypes, EffectNames, EventNames, Locations } = require('./Constants');
 
 class Conflict extends GameObject {
     constructor(game, attackingPlayer, defendingPlayer, ring = null, conflictProvince = null, forcedDeclaredType = null) {
@@ -228,12 +228,25 @@ class Conflict extends GameObject {
             return stateChanged;
         }
 
-        let additionalCharacters = this.getEffects(EffectNames.ContributeToConflict);
+        const contributingLocations = [
+            Locations.PlayArea,
+            Locations.ProvinceOne,
+            Locations.ProvinceTwo,
+            Locations.ProvinceThree,
+            Locations.ProvinceFour
+        ];
+
+        let additionalContributingCards = this.game.findAnyCardsInAnyList(card =>
+            card.type === CardTypes.Character &&
+            contributingLocations.includes(card.location) &&
+            card.anyEffect(EffectNames.ContributeToConflict)
+        );
 
         if(this.attackingPlayer.anyEffect(EffectNames.SetConflictTotalSkill)) {
             this.attackerSkill = this.attackingPlayer.mostRecentEffect(EffectNames.SetConflictTotalSkill);
         } else {
-            let additionalAttackers = additionalCharacters.filter(card => card.controller === this.attackingPlayer);
+            let additionalAttackers = additionalContributingCards
+                .filter(card => card.getEffects(EffectNames.ContributeToConflict).some(value => value === this.attackingPlayer));
             this.attackerSkill = this.calculateSkillFor(this.attackers.concat(additionalAttackers)) + this.attackingPlayer.skillModifier;
             if(this.attackingPlayer.imperialFavor === this.conflictType && this.attackers.length > 0) {
                 this.attackerSkill++;
@@ -243,7 +256,8 @@ class Conflict extends GameObject {
         if(this.defendingPlayer.anyEffect(EffectNames.SetConflictTotalSkill)) {
             this.defenderSkill = this.defendingPlayer.mostRecentEffect(EffectNames.SetConflictTotalSkill);
         } else {
-            let additionalDefenders = additionalCharacters.filter(card => card.controller === this.defendingPlayer);
+            let additionalDefenders = additionalContributingCards
+                .filter(card => card.getEffects(EffectNames.ContributeToConflict).some(value => value === this.defendingPlayer));
             this.defenderSkill = this.calculateSkillFor(this.defenders.concat(additionalDefenders)) + this.defendingPlayer.skillModifier;
             if(this.defendingPlayer.imperialFavor === this.conflictType && this.defenders.length > 0) {
                 this.defenderSkill++;

--- a/server/game/conflict.js
+++ b/server/game/conflict.js
@@ -233,7 +233,8 @@ class Conflict extends GameObject {
             Locations.ProvinceOne,
             Locations.ProvinceTwo,
             Locations.ProvinceThree,
-            Locations.ProvinceFour
+            Locations.ProvinceFour,
+            Locations.StrongholdProvince
         ];
 
         let additionalContributingCards = this.game.findAnyCardsInAnyList(card =>
@@ -268,7 +269,7 @@ class Conflict extends GameObject {
     }
 
     calculateSkillFor(cards) {
-        let skillFunction = this.mostRecentEffect(EffectNames.ChangeConflictSkillFunction) || (card => card.getSkill(this.conflictType));
+        let skillFunction = this.mostRecentEffect(EffectNames.ChangeConflictSkillFunction) || (card => card.getContributionToConflict(this.conflictType));
         let cannotContributeFunctions = this.getEffects(EffectNames.CannotContribute);
         return cards.reduce((sum, card) => {
             let cannotContribute = card.bowed;

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -207,16 +207,21 @@ class DrawCard extends BaseCard {
         return isNaN(baseSkillModifiers.baseMilitarySkill) || isNaN(baseSkillModifiers.basePoliticalSkill);
     }
 
+    getContributionToConflict(type) {
+        let skillFunction = this.mostRecentEffect(EffectNames.ChangeContributionFunction);
+        if(skillFunction) {
+            return skillFunction(this);
+        }
+        return this.getSkill(type);
+    }
+
     /**
      * Direct the skill query to the correct sub function.
      * @param  {string} type - The type of the skill; military or political
      * @return {number} The chosen skill value
      */
     getSkill(type) {
-        let skillFunction = this.mostRecentEffect(EffectNames.ChangeSkillFunction);
-        if(skillFunction) {
-            return skillFunction(this);
-        } else if(type === 'military') {
+        if(type === 'military') {
             return this.getMilitarySkill();
         } else if(type === 'political') {
             return this.getPoliticalSkill();

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -207,13 +207,16 @@ class DrawCard extends BaseCard {
         return isNaN(baseSkillModifiers.baseMilitarySkill) || isNaN(baseSkillModifiers.basePoliticalSkill);
     }
 
+    /**
+     * Direct the skill query to the correct sub function.
+     * @param  {string} type - The type of the skill; military or political
+     * @return {number} The chosen skill value
+     */
     getSkill(type) {
-        /**
-         * Direct the skill query to the correct sub function.
-         * @param  {string} type - The type of the skill; military or political
-         * @return {integer} The chosen skill value
-         */
-        if(type === 'military') {
+        let skillFunction = this.mostRecentEffect(EffectNames.ChangeSkillFunction);
+        if(skillFunction) {
+            return skillFunction(this);
+        } else if(type === 'military') {
             return this.getMilitarySkill();
         } else if(type === 'political') {
             return this.getPoliticalSkill();

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -29,7 +29,7 @@ const Effects = {
     cannotParticipateAsAttacker: (type = 'both') => EffectBuilder.card.static(EffectNames.CannotParticipateAsAttacker, type),
     cannotParticipateAsDefender: (type = 'both') => EffectBuilder.card.static(EffectNames.CannotParticipateAsDefender, type),
     cardCannot: (properties) => EffectBuilder.card.static(EffectNames.AbilityRestrictions, new Restriction(Object.assign({ type: properties.cannot || properties }, properties))),
-    changeSkillFunction: (func) => EffectBuilder.card.static(EffectNames.ChangeSkillFunction, func),
+    changeContributionFunction: (func) => EffectBuilder.card.static(EffectNames.ChangeContributionFunction, func),
     contributeToConflict: (player) => EffectBuilder.card.flexible(EffectNames.ContributeToConflict, player),
     copyCharacter: (character) => EffectBuilder.card.static(EffectNames.CopyCharacter, new CopyCharacter(character)),
     customDetachedCard: (properties) => EffectBuilder.card.detached(EffectNames.CustomEffect, properties),

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -29,6 +29,7 @@ const Effects = {
     cannotParticipateAsAttacker: (type = 'both') => EffectBuilder.card.static(EffectNames.CannotParticipateAsAttacker, type),
     cannotParticipateAsDefender: (type = 'both') => EffectBuilder.card.static(EffectNames.CannotParticipateAsDefender, type),
     cardCannot: (properties) => EffectBuilder.card.static(EffectNames.AbilityRestrictions, new Restriction(Object.assign({ type: properties.cannot || properties }, properties))),
+    contributeToConflict: (player) => EffectBuilder.card.flexible(EffectNames.ContributeToConflict, player),
     copyCharacter: (character) => EffectBuilder.card.static(EffectNames.CopyCharacter, new CopyCharacter(character)),
     customDetachedCard: (properties) => EffectBuilder.card.detached(EffectNames.CustomEffect, properties),
     delayedEffect: (properties) => EffectBuilder.card.detached(EffectNames.DelayedEffect, {
@@ -154,7 +155,6 @@ const Effects = {
     setConflictTotalSkill: (value) => EffectBuilder.player.static(EffectNames.SetConflictTotalSkill, value),
     showTopConflictCard: () => EffectBuilder.player.static(EffectNames.ShowTopConflictCard),
     // Conflict effects
-    contributeToConflict: (card) => EffectBuilder.conflict.flexible(EffectNames.ContributeToConflict, card),
     changeConflictSkillFunction: (func) => EffectBuilder.conflict.static(EffectNames.ChangeConflictSkillFunction, func), // TODO: Add this to lasting effect checks
     modifyConflictElementsToResolve: (value) => EffectBuilder.conflict.static(EffectNames.ModifyConflictElementsToResolve, value), // TODO: Add this to lasting effect checks
     restrictNumberOfDefenders: (value) => EffectBuilder.conflict.static(EffectNames.RestrictNumberOfDefenders, value), // TODO: Add this to lasting effect checks

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -29,6 +29,7 @@ const Effects = {
     cannotParticipateAsAttacker: (type = 'both') => EffectBuilder.card.static(EffectNames.CannotParticipateAsAttacker, type),
     cannotParticipateAsDefender: (type = 'both') => EffectBuilder.card.static(EffectNames.CannotParticipateAsDefender, type),
     cardCannot: (properties) => EffectBuilder.card.static(EffectNames.AbilityRestrictions, new Restriction(Object.assign({ type: properties.cannot || properties }, properties))),
+    changeSkillFunction: (func) => EffectBuilder.card.static(EffectNames.ChangeSkillFunction, func),
     contributeToConflict: (player) => EffectBuilder.card.flexible(EffectNames.ContributeToConflict, player),
     copyCharacter: (character) => EffectBuilder.card.static(EffectNames.CopyCharacter, new CopyCharacter(character)),
     customDetachedCard: (properties) => EffectBuilder.card.detached(EffectNames.CustomEffect, properties),

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -155,6 +155,7 @@ const Effects = {
     setConflictTotalSkill: (value) => EffectBuilder.player.static(EffectNames.SetConflictTotalSkill, value),
     showTopConflictCard: () => EffectBuilder.player.static(EffectNames.ShowTopConflictCard),
     // Conflict effects
+    cannotContribute: (func) => EffectBuilder.conflict.dynamic(EffectNames.CannotContribute, func),
     changeConflictSkillFunction: (func) => EffectBuilder.conflict.static(EffectNames.ChangeConflictSkillFunction, func), // TODO: Add this to lasting effect checks
     modifyConflictElementsToResolve: (value) => EffectBuilder.conflict.static(EffectNames.ModifyConflictElementsToResolve, value), // TODO: Add this to lasting effect checks
     restrictNumberOfDefenders: (value) => EffectBuilder.conflict.static(EffectNames.RestrictNumberOfDefenders, value), // TODO: Add this to lasting effect checks

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -229,6 +229,15 @@ class Game extends EventEmitter {
     }
 
     /**
+     * Returns all cards from anywhere in the game matching the passed predicate
+     * @param {Function} predicate - card => Boolean
+     * @returns {Array} Array of DrawCard objects
+     */
+    findAnyCardsInAnyList(predicate) {
+        return this.allCards.filter(predicate);
+    }
+
+    /**
      * Returns all cards (i.e. characters) which matching the passed predicated
      * function from either players 'in play' area.
      * @param {Function} predicate - card => Boolean

--- a/test/server/card/drawcard.moveto.spec.js
+++ b/test/server/card/drawcard.moveto.spec.js
@@ -5,12 +5,37 @@ describe('DrawCard', function () {
         this.testCard = { code: '111', label: 'test 1(some pack)', name: 'test 1' };
         this.gameSpy = jasmine.createSpyObj('game', ['emitEvent']);
         this.card = new DrawCard({ game: this.gameSpy }, this.testCard);
+        spyOn(this.card, 'removeLastingEffects');
     });
 
     describe('moveTo()', function() {
         it('should set the location', function() {
             this.card.moveTo('hand');
             expect(this.card.location).toBe('hand');
+        });
+
+        it('should call removeLastingEffects if moved between out of play areas', function() {
+            this.card.moveTo('dynasty discard pile');
+            this.card.moveTo('hand');
+            expect(this.card.removeLastingEffects.calls.count()).toBe(2);
+        });
+
+        it('should call removeLastingEffects if moved from out of play to play area', function() {
+            this.card.moveTo('province 1');
+            this.card.moveTo('play area');
+            expect(this.card.removeLastingEffects.calls.count()).toBe(2);
+        });
+
+        it('should call removeLastingEffects if moved from play area to an out of play area', function() {
+            this.card.moveTo('play area');
+            this.card.moveTo('conflict discard pile');
+            expect(this.card.removeLastingEffects.calls.count()).toBe(2);
+        });
+
+        it('should not call removeLastingEffects if moved between provinces', function() {
+            this.card.moveTo('province 1');
+            this.card.moveTo('province 2');
+            expect(this.card.removeLastingEffects.calls.count()).toBe(1);
         });
 
         describe('when the card is facedown', function() {

--- a/test/server/card/provincecard.moveto.spec.js
+++ b/test/server/card/provincecard.moveto.spec.js
@@ -6,6 +6,7 @@ describe('ProvinceCard', function () {
         this.gameSpy = jasmine.createSpyObj('game', ['emitEvent', 'on']);
         this.card = new ProvinceCard({ game: this.gameSpy }, this.testCard);
         this.card.type = 'province';
+        spyOn(this.card, 'removeLastingEffects');
     });
 
     describe('moveTo()', function() {

--- a/test/server/cards/02.5-FHNS/CunningMagistrate.spec.js
+++ b/test/server/cards/02.5-FHNS/CunningMagistrate.spec.js
@@ -1,0 +1,59 @@
+describe('Cunning Magistrate', function() {
+    integration(function() {
+        describe('Cunning Magistrate\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['cunning-magistrate', 'adept-of-shadows'],
+                        hand: ['way-of-the-scorpion']
+                    },
+                    player2: {
+                        inPlay: ['doji-whisperer', 'doji-challenger'],
+                        hand: ['court-games']
+                    }
+                });
+
+                this.cunningMagistrate = this.player1.findCardByName('cunning-magistrate');
+                this.adeptOfShadows = this.player1.findCardByName('adept-of-shadows');
+                this.wayOfTheScorpion = this.player1.findCardByName('way-of-the-scorpion');
+                this.dojiWhisperer = this.player2.findCardByName('doji-whisperer');
+                this.dojiChallenger = this.player2.findCardByName('doji-challenger');
+                this.courtGames = this.player2.findCardByName('court-games');
+            });
+
+            it('should prevent dishonored characters from contributing to the conflict', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.cunningMagistrate, this.adeptOfShadows],
+                    defenders: [this.dojiWhisperer, this.dojiChallenger],
+                    type: 'political'
+                });
+                expect(this.game.currentConflict.attackerSkill).toBe(4);
+                expect(this.game.currentConflict.defenderSkill).toBe(6);
+                this.player2.pass();
+                this.player1.clickCard(this.wayOfTheScorpion);
+                this.player1.clickCard(this.dojiWhisperer);
+                expect(this.game.currentConflict.attackerSkill).toBe(4);
+                expect(this.game.currentConflict.defenderSkill).toBe(3);
+            });
+
+            it('should not prevent itselft contributing to the conflict', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.cunningMagistrate, this.adeptOfShadows],
+                    defenders: [this.dojiWhisperer, this.dojiChallenger],
+                    type: 'political'
+                });
+                expect(this.game.currentConflict.attackerSkill).toBe(4);
+                expect(this.game.currentConflict.defenderSkill).toBe(6);
+                this.player2.clickCard(this.courtGames);
+                this.player2.clickPrompt('Dishonor an opposing character');
+                this.player1.clickCard(this.cunningMagistrate);
+                expect(this.cunningMagistrate.isDishonored).toBe(true);
+                expect(this.game.currentConflict.attackerSkill).toBe(3);
+                expect(this.game.currentConflict.defenderSkill).toBe(6);
+            });
+        });
+    });
+});

--- a/test/server/cards/09.2-BoB/HirumaYoshino.spec.js
+++ b/test/server/cards/09.2-BoB/HirumaYoshino.spec.js
@@ -5,17 +5,19 @@ describe('Hiruma Yoshino', function() {
                 this.setupTest({
                     phase: 'conflict',
                     player1: {
-                        inPlay: ['hiruma-yoshino', 'borderlands-defender'],
+                        inPlay: ['hiruma-yoshino', 'borderlands-defender', 'humble-magistrate'],
                         dynastyDiscard: ['hida-kisada', 'eager-scout']
                     },
                     player2: {
                         inPlay: ['matsu-berserker'],
+                        hand: ['charge'],
                         dynastyDiscard: ['akodo-toturi', 'favorable-ground', 'venerable-historian']
                     }
                 });
 
                 this.hirumaYoshino = this.player1.findCardByName('hiruma-yoshino');
                 this.borderlandsDefender = this.player1.findCardByName('borderlands-defender');
+                this.humbleMagistrate = this.player1.findCardByName('humble-magistrate');
                 this.hidaKisada = this.player1.findCardByName('hida-kisada', 'dynasty discard pile');
                 this.eagerScout = this.player1.findCardByName('eager-scout', 'dynasty discard pile');
                 this.player1.placeCardInProvince(this.hidaKisada, 'province 1');
@@ -23,6 +25,7 @@ describe('Hiruma Yoshino', function() {
                 this.P1shamefulDisplay2 = this.player1.findCardByName('shameful-display', 'province 2');
 
                 this.matsuBerserker = this.player2.findCardByName('matsu-berserker');
+                this.charge = this.player2.findCardByName('charge');
                 this.akodoToturi = this.player2.findCardByName('akodo-toturi', 'dynasty discard pile');
                 this.favorableGround = this.player2.findCardByName('favorable-ground', 'dynasty discard pile');
                 this.venerableHistorian = this.player2.findCardByName('venerable-historian', 'dynasty discard pile');
@@ -142,6 +145,34 @@ describe('Hiruma Yoshino', function() {
                 expect(this.player1).toHavePrompt('Conflict Action Window');
                 this.player1.clickCard(this.hirumaYoshino);
                 expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('should no longer contribute skill if the targeted character is moved from the province', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.hirumaYoshino],
+                    defenders: []
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.hirumaYoshino);
+                this.player1.clickCard(this.akodoToturi);
+                expect(this.game.currentConflict.attackerSkill).toBe(9);
+                this.player2.clickCard(this.charge);
+                this.player2.clickCard(this.akodoToturi);
+                expect(this.akodoToturi.location).toBe('play area');
+                expect(this.game.currentConflict.attackerSkill).toBe(3);
+            });
+
+            it('should not contribute if there is a constant effect that prevents contribution (magistrates)', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.hirumaYoshino, this.humbleMagistrate],
+                    defenders: []
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.hirumaYoshino);
+                this.player1.clickCard(this.akodoToturi);
+                expect(this.game.currentConflict.attackerSkill).toBe(2);
             });
         });
     });

--- a/test/server/cards/09.2-BoB/HirumaYoshino.spec.js
+++ b/test/server/cards/09.2-BoB/HirumaYoshino.spec.js
@@ -11,7 +11,7 @@ describe('Hiruma Yoshino', function() {
                     player2: {
                         inPlay: ['matsu-berserker'],
                         hand: ['charge'],
-                        dynastyDiscard: ['akodo-toturi', 'favorable-ground', 'venerable-historian'],
+                        dynastyDiscard: ['akodo-toturi', 'favorable-ground', 'venerable-historian', 'akodo-makoto'],
                         provinces: ['shameful-display', 'shameful-display', 'shameful-display', 'sanpuku-seido']
                     }
                 });
@@ -30,12 +30,14 @@ describe('Hiruma Yoshino', function() {
                 this.akodoToturi = this.player2.findCardByName('akodo-toturi', 'dynasty discard pile');
                 this.favorableGround = this.player2.findCardByName('favorable-ground', 'dynasty discard pile');
                 this.venerableHistorian = this.player2.findCardByName('venerable-historian', 'dynasty discard pile');
+                this.akodoMakoto = this.player2.findCardByName('akodo-makoto', 'dynasty discard pile');
                 this.P2shamefulDisplay2 = this.player2.findCardByName('shameful-display', 'province 2');
                 this.P2shamefulDisplay3 = this.player2.findCardByName('shameful-display', 'province 3');
                 this.P2sanpukuSeido4 = this.player2.findCardByName('sanpuku-seido', 'province 4');
                 this.player2.placeCardInProvince(this.akodoToturi, 'province 1');
                 this.player2.placeCardInProvince(this.favorableGround, 'province 2');
                 this.player2.placeCardInProvince(this.venerableHistorian, 'province 3');
+                this.player2.placeCardInProvince(this.akodoMakoto, 'province 4');
             });
 
             it('should not trigger outside of a military conflict', function() {
@@ -175,6 +177,20 @@ describe('Hiruma Yoshino', function() {
                 this.player1.clickCard(this.hirumaYoshino);
                 this.player1.clickCard(this.akodoToturi);
                 expect(this.game.currentConflict.attackerSkill).toBe(2);
+            });
+
+            it('should contibute the target\'s glory if the conflict is at Sanpuku Seido ', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.hirumaYoshino],
+                    defenders: [],
+                    province: this.P2sanpukuSeido4
+                });
+                this.player2.pass();
+                expect(this.game.currentConflict.attackerSkill).toBe(2);
+                this.player1.clickCard(this.hirumaYoshino);
+                this.player1.clickCard(this.akodoMakoto);
+                expect(this.game.currentConflict.attackerSkill).toBe(3);
             });
         });
     });

--- a/test/server/cards/09.2-BoB/HirumaYoshino.spec.js
+++ b/test/server/cards/09.2-BoB/HirumaYoshino.spec.js
@@ -6,7 +6,8 @@ describe('Hiruma Yoshino', function() {
                     phase: 'conflict',
                     player1: {
                         inPlay: ['hiruma-yoshino', 'borderlands-defender', 'humble-magistrate'],
-                        dynastyDiscard: ['hida-kisada', 'eager-scout']
+                        dynastyDiscard: ['hida-kisada', 'eager-scout', 'crisis-breaker'],
+                        provinces: ['shameful-display', 'shameful-display', 'kuroi-mori']
                     },
                     player2: {
                         inPlay: ['matsu-berserker'],
@@ -21,9 +22,12 @@ describe('Hiruma Yoshino', function() {
                 this.humbleMagistrate = this.player1.findCardByName('humble-magistrate');
                 this.hidaKisada = this.player1.findCardByName('hida-kisada', 'dynasty discard pile');
                 this.eagerScout = this.player1.findCardByName('eager-scout', 'dynasty discard pile');
+                this.crisisBreaker = this.player1.findCardByName('crisis-breaker', 'dynasty discard pile');
                 this.player1.placeCardInProvince(this.hidaKisada, 'province 1');
                 this.player1.placeCardInProvince(this.eagerScout, 'province 2');
+                this.player1.placeCardInProvince(this.crisisBreaker, 'province 3');
                 this.P1shamefulDisplay2 = this.player1.findCardByName('shameful-display', 'province 2');
+                this.P1kuroiMori3 = this.player1.findCardByName('kuroi-mori', 'province 3');
 
                 this.matsuBerserker = this.player2.findCardByName('matsu-berserker');
                 this.charge = this.player2.findCardByName('charge');
@@ -179,7 +183,7 @@ describe('Hiruma Yoshino', function() {
                 expect(this.game.currentConflict.attackerSkill).toBe(2);
             });
 
-            it('should contibute the target\'s glory if the conflict is at Sanpuku Seido ', function() {
+            it('should contibute the target\'s glory if the conflict is at Sanpuku Seido', function() {
                 this.noMoreActions();
                 this.initiateConflict({
                     attackers: [this.hirumaYoshino],
@@ -191,6 +195,25 @@ describe('Hiruma Yoshino', function() {
                 this.player1.clickCard(this.hirumaYoshino);
                 this.player1.clickCard(this.akodoMakoto);
                 expect(this.game.currentConflict.attackerSkill).toBe(3);
+            });
+
+            it('should contibute the target\'s military skill even if the conflict is changed to political', function() {
+                this.noMoreActions();
+                this.player1.passConflict();
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.matsuBerserker],
+                    defenders: [this.hirumaYoshino],
+                    province: this.P1kuroiMori3
+                });
+                expect(this.game.currentConflict.defenderSkill).toBe(3);
+                this.player1.clickCard(this.hirumaYoshino);
+                this.player1.clickCard(this.crisisBreaker);
+                expect(this.game.currentConflict.defenderSkill).toBe(6);
+                this.player2.pass();
+                this.player1.clickCard(this.P1kuroiMori3);
+                this.player1.clickPrompt('Switch the conflict type');
+                expect(this.game.currentConflict.defenderSkill).toBe(6);
             });
         });
     });

--- a/test/server/cards/09.2-BoB/HirumaYoshino.spec.js
+++ b/test/server/cards/09.2-BoB/HirumaYoshino.spec.js
@@ -11,7 +11,8 @@ describe('Hiruma Yoshino', function() {
                     player2: {
                         inPlay: ['matsu-berserker'],
                         hand: ['charge'],
-                        dynastyDiscard: ['akodo-toturi', 'favorable-ground', 'venerable-historian']
+                        dynastyDiscard: ['akodo-toturi', 'favorable-ground', 'venerable-historian'],
+                        provinces: ['shameful-display', 'shameful-display', 'shameful-display', 'sanpuku-seido']
                     }
                 });
 
@@ -31,6 +32,7 @@ describe('Hiruma Yoshino', function() {
                 this.venerableHistorian = this.player2.findCardByName('venerable-historian', 'dynasty discard pile');
                 this.P2shamefulDisplay2 = this.player2.findCardByName('shameful-display', 'province 2');
                 this.P2shamefulDisplay3 = this.player2.findCardByName('shameful-display', 'province 3');
+                this.P2sanpukuSeido4 = this.player2.findCardByName('sanpuku-seido', 'province 4');
                 this.player2.placeCardInProvince(this.akodoToturi, 'province 1');
                 this.player2.placeCardInProvince(this.favorableGround, 'province 2');
                 this.player2.placeCardInProvince(this.venerableHistorian, 'province 3');

--- a/test/server/conflict/removefromconflict.spec.js
+++ b/test/server/conflict/removefromconflict.spec.js
@@ -4,10 +4,11 @@ const DrawCard = require('../../../build/server/game/drawcard.js');
 
 describe('Conflict', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['applyGameAction', 'on', 'raiseEvent', 'reapplyStateDependentEffects', 'getFrameworkContext']);
+        this.gameSpy = jasmine.createSpyObj('game', ['applyGameAction', 'findAnyCardsInAnyList', 'on', 'raiseEvent', 'reapplyStateDependentEffects', 'getFrameworkContext']);
         this.gameSpy.applyGameAction.and.callFake((type, card, handler) => {
             handler(card);
         });
+        this.gameSpy.findAnyCardsInAnyList.and.returnValue([]);
         this.effectEngineSpy = jasmine.createSpyObj('effectEngine', ['checkEffects']);
         this.gameSpy.effectEngine = this.effectEngineSpy;
 


### PR DESCRIPTION
Closes #3322 

This ended up a bit of a beast of a PR.

All of the "cannot contibute" magistrates have been changed to now affect the conflict and not the cards using the new `cannotContribute` effect.

Any lasting effects on cards are now removed when moving between any locations except between provinces.

Also added a new `changeSkillFunction` effect for cards that will override any requests for getSkill().

Additional contributors to the conflict are now not based upon the controller of the card, but by the player specified as part of the effect.