### PR TITLE
Fix issue #3632 - Emperor's Summons Places the chosen card facedown

### DIFF
--- a/server/game/cards/09.4-TCoH/EmperorsSummons.js
+++ b/server/game/cards/09.4-TCoH/EmperorsSummons.js
@@ -19,7 +19,7 @@ class EmperorsSummons extends ProvinceCard {
                     controller: Players.Self,
                     cardCondition: card => card.location !== Locations.StrongholdProvince,
                     subActionProperties: card => ({ destination: card.location }),
-                    gameAction: AbilityDsl.actions.moveCard({ discardDestinationCards: true }),
+                    gameAction: AbilityDsl.actions.moveCard({ discardDestinationCards: true, faceup: true }),
                     message: '{1} chooses to place {2} in {0} discarding {3}',
                     messageArgs: (card, player, properties) => [card.location, player, properties.target, player.getDynastyCardInProvince(card.location)]
                 })

--- a/test/server/cards/09.4-TCoH/EmperorsSummons.spec.js
+++ b/test/server/cards/09.4-TCoH/EmperorsSummons.spec.js
@@ -64,7 +64,7 @@ describe('Emperor\'s Summons', function() {
                 expect(this.getChatLogs(2)).toContain('player2 selects nothing from their deck');
             });
 
-            it('should place the selected charater in the chosen province, discarding each other card in that province', function() {
+            it('should place the selected charater in the chosen province, discarding each other card in that province, face up', function() {
                 this.noMoreActions();
                 const cardsInDiscard = this.player2.player.dynastyDiscardPile.size();
                 this.player1.clickCard(this.brashSamurai);
@@ -75,6 +75,7 @@ describe('Emperor\'s Summons', function() {
                 this.player2.clickPrompt('Mirumoto Raitsugu');
                 this.player2.clickCard(this.shamefulDisplay);
                 expect(this.mirumotoRaitsugu.location).toBe('province 2');
+                expect(this.mirumotoRaitsugu.facedown).toBe(false);
                 expect(this.player2.player.dynastyDiscardPile.size()).toBe(cardsInDiscard + 1);
                 expect(this.getChatLogs(2)).toContain('player2 chooses to place Mirumoto Raitsugu in province 2 discarding Adept of the Waves');
             });


### PR DESCRIPTION
Fix for issue#3632, Test added to verify card is faceup. 