### PR TITLE
Fix #3645: Sharpen the mind filters discards incorrectly

### DIFF
--- a/server/game/cards/09.3-JfS/SharpenTheMind.js
+++ b/server/game/cards/09.3-JfS/SharpenTheMind.js
@@ -1,11 +1,12 @@
 const DrawCard = require('../../drawcard.js');
 const AbilityDsl = require('../../abilitydsl');
+const { Locations } = require('../../Constants');
 
 class SharpenTheMind extends DrawCard {
     setupCardAbilities() {
         this.action({
             title: 'Give +3/+3 to attached character',
-            cost: AbilityDsl.costs.discardCard(),
+            cost: AbilityDsl.costs.discardCard({ location: Locations.Hand }),
             condition: context => context.game.isDuringConflict(),
             gameAction: AbilityDsl.actions.cardLastingEffect(context => ({
                 target: context.source.parent,

--- a/test/server/cards/09.3-JfS/SharpenTheMind.spec.js
+++ b/test/server/cards/09.3-JfS/SharpenTheMind.spec.js
@@ -6,7 +6,8 @@ describe('Sharpen the Mind', function() {
                     phase: 'conflict',
                     player1: {
                         inPlay: ['brash-samurai'],
-                        hand: ['sharpen-the-mind', 'fine-katana', 'ornate-fan']
+                        hand: ['sharpen-the-mind', 'fine-katana', 'ornate-fan'],
+                        conflictDiscard: ['guidance-of-the-ancestors']
                     },
                     player2: {
                     }
@@ -15,6 +16,7 @@ describe('Sharpen the Mind', function() {
                 this.sharpenTheMind = this.player1.findCardByName('sharpen-the-mind');
                 this.fineKatana = this.player1.findCardByName('fine-katana');
                 this.ornateFan = this.player1.findCardByName('ornate-fan');
+                this.guidanceOfTheAncestors = this.player1.findCardByName('guidance-of-the-ancestors');
 
                 this.player1.playAttachment(this.sharpenTheMind, this.brashSamurai);
             });
@@ -38,6 +40,22 @@ describe('Sharpen the Mind', function() {
                 expect(this.player1).toBeAbleToSelect(this.fineKatana);
                 expect(this.player1).toBeAbleToSelect(this.ornateFan);
             });
+
+            it('should only prompt to discard from hand', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.brashSamurai],
+                    defenders: []
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.sharpenTheMind);
+                expect(this.player1).toHavePrompt('Select card to discard');
+                expect(this.player1).toBeAbleToSelect(this.fineKatana);
+                expect(this.player1).toBeAbleToSelect(this.ornateFan);
+                expect(this.player1).not.toBeAbleToSelect(this.brashSamurai);
+                expect(this.player1).not.toBeAbleToSelect(this.guidanceOfTheAncestors);
+            });
+
 
             it('should discard the chosen card', function() {
                 this.noMoreActions();


### PR DESCRIPTION
Added test case to reproduce error behavior.
Updated Sharpen The Mind implementation to only permit choosing from hand.