### PR TITLE
Fix for #3638 - Overhear logs wrong card

### DIFF
--- a/server/game/cards/09.4-TCoH/Overhear.js
+++ b/server/game/cards/09.4-TCoH/Overhear.js
@@ -7,11 +7,19 @@ class Overhear extends DrawCard {
     setupCardAbilities() {
         this.action({
             title: 'Place random card on top of deck',
-            condition: context => context.game.isDuringConflict('political'),
-            gameAction: AbilityDsl.actions.moveCard(context => ({
+            effect: 'reveal a random card from {1}\'s hand and place it on top of {1}\'s deck',
+            effectArgs: context=> [context.player.opponent],
+            gameAction:AbilityDsl.actions.sequential([AbilityDsl.actions.moveCard(context => ({
                 target: context.player.opponent && context.player.opponent.hand.shuffle().slice(0, 1),
                 destination: Locations.ConflictDeck
-            })),
+            })), 
+                AbilityDsl.actions.lookAt(context => ({
+                    target: context.player.opponent.conflictDeck.first(1),
+                    message: '{0} sees {1}', 
+                    messageArgs : cards => ([context.player, cards[0]])
+                }))
+            ]),
+            condition: context => context.game.isDuringConflict('political'),
             then: context => {
                 if(context.game.currentConflict.getCharacters(context.player).filter(card => card.hasTrait('courtier')).length < 1) {
                     return;

--- a/server/game/cards/09.4-TCoH/Overhear.js
+++ b/server/game/cards/09.4-TCoH/Overhear.js
@@ -12,12 +12,12 @@ class Overhear extends DrawCard {
             gameAction:AbilityDsl.actions.sequential([AbilityDsl.actions.moveCard(context => ({
                 target: context.player.opponent && context.player.opponent.hand.shuffle().slice(0, 1),
                 destination: Locations.ConflictDeck
-            })), 
-                AbilityDsl.actions.lookAt(context => ({
-                    target: context.player.opponent.conflictDeck.first(1),
-                    message: '{0} sees {1}', 
-                    messageArgs : cards => ([context.player, cards[0]])
-                }))
+            })),
+            AbilityDsl.actions.lookAt(context => ({
+                target: context.player.opponent.conflictDeck.first(1),
+                message: '{0} sees {1}',
+                messageArgs : cards => ([context.player, cards[0]])
+            }))
             ]),
             condition: context => context.game.isDuringConflict('political'),
             then: context => {

--- a/test/server/cards/09.4-TCoH/Overhear.spec.js
+++ b/test/server/cards/09.4-TCoH/Overhear.spec.js
@@ -37,7 +37,7 @@ describe('Overhear', function() {
                 expect(this.player1).toHavePrompt('Conflict Action Window');
             });
 
-            it('should put a random card from your opponent\'s hand on top of their deck', function() {
+            it('should put a random card from your opponent\'s hand on top of their deck, and correctly log it', function() {
                 let handSize = this.player2.hand.length;
                 let deckSize = this.player2.conflictDeck.length;
                 this.noMoreActions();
@@ -50,11 +50,14 @@ describe('Overhear', function() {
                 this.player1.clickCard(this.overhear);
                 expect(this.player2.hand.length).toBe(handSize - 1);
                 expect(this.player2.conflictDeck.length).toBe(deckSize + 1);
-                expect([
-                    'player1 plays Overhear to move Fine Katana to player2\'s conflict deck',
-                    'player1 plays Overhear to move Ornate Fan to player2\'s conflict deck',
-                    'player1 plays Overhear to move Banzai! to player2\'s conflict deck'
-                ]).toContain(this.getChatLogs(1)[0]);
+                expect([ 
+                    'player1 sees Fine Katana', 
+                    'player1 sees Ornate Fan',
+                    'player1 sees Banzai!'
+                ]).toContain(this.getChatLogs(1)[0])
+                expect(
+                    `player1 sees ${ this.player2.conflictDeck[0].name }`
+                ).toEqual(this.getChatLogs(1)[0]);
             });
 
             it('should not prompt to resolve a second time if you do not have a participating courtier', function() {
@@ -97,7 +100,7 @@ describe('Overhear', function() {
                 this.player1.clickPrompt('Give 1 honor to resolve this ability again');
                 expect(this.player1.player.honor).toBe(honorP1 - 1);
                 expect(this.player2.player.honor).toBe(honorP2 + 1);
-                expect(this.getChatLogs(2)).toContain('player1 chooses to give an honor to player2 to resolve Overhear again');
+                expect(this.getChatLogs(3)).toContain('player1 chooses to give an honor to player2 to resolve Overhear again');
             });
 
             it('should end if you choose not to resolve again', function() {

--- a/test/server/cards/09.4-TCoH/Overhear.spec.js
+++ b/test/server/cards/09.4-TCoH/Overhear.spec.js
@@ -50,11 +50,11 @@ describe('Overhear', function() {
                 this.player1.clickCard(this.overhear);
                 expect(this.player2.hand.length).toBe(handSize - 1);
                 expect(this.player2.conflictDeck.length).toBe(deckSize + 1);
-                expect([ 
-                    'player1 sees Fine Katana', 
+                expect([
+                    'player1 sees Fine Katana',
                     'player1 sees Ornate Fan',
                     'player1 sees Banzai!'
-                ]).toContain(this.getChatLogs(1)[0])
+                ]).toContain(this.getChatLogs(1)[0]);
                 expect(
                     `player1 sees ${ this.player2.conflictDeck[0].name }`
                 ).toEqual(this.getChatLogs(1)[0]);


### PR DESCRIPTION
Resolves Issue #3638
Overhear now sequentially moves a random card to top of opponent's deck, then uses a LookAt action to reveal said card. 