### PR TITLE
Fix #3592: SYH does not cancel Hitomi duel

### DIFF
--- a/server/game/cards/06-CotE/StayYourHand.js
+++ b/server/game/cards/06-CotE/StayYourHand.js
@@ -8,7 +8,8 @@ class StayYourHand extends DrawCard {
             when: {
                 onDuelInitiated: (event, context) =>
                     event.context.player === context.player.opponent &&
-                    _.some(event.context.targets, (card) => card.controller === context.player)
+                    (_.some(event.context.targets, (card) => card.controller === context.player) ||
+                    (event.context.targets.target && _.some(event.context.targets.target, (card) => card.controller === context.player)))
             },
             cannotBeMirrored: true,
             effect: 'cancel the duel originating from {1}',

--- a/test/server/cards/06-CotE/StayYourHand.spec.js
+++ b/test/server/cards/06-CotE/StayYourHand.spec.js
@@ -5,19 +5,21 @@ describe('Stay Your Hand', function() {
                 this.setupTest({
                     phase: 'conflict',
                     player1: {
-                        inPlay: ['honest-challenger'],
+                        inPlay: ['honest-challenger', 'brash-samurai'],
                         hand: ['stay-your-hand', 'game-of-sadane']
                     },
                     player2: {
-                        inPlay: ['mirumoto-raitsugu'],
+                        inPlay: ['mirumoto-raitsugu', 'mirumoto-hitomi'],
                         hand: ['policy-debate']
                     }
                 });
                 this.honestChallenger = this.player1.findCardByName('honest-challenger');
+                this.brashSamurai = this.player1.findCardByName('brash-samurai');
                 this.stayYourHand = this.player1.findCardByName('stay-your-hand');
                 this.gameOfSadane = this.player1.findCardByName('game-of-sadane');
 
                 this.mirumotoRaitsugu = this.player2.findCardByName('mirumoto-raitsugu');
+                this.mirumotoHitomi = this.player2.findCardByName('mirumoto-hitomi');
                 this.policyDebate = this.player2.findCardByName('policy-debate');
             });
 
@@ -72,6 +74,20 @@ describe('Stay Your Hand', function() {
                 this.player1.clickCard(this.stayYourHand);
                 expect(this.player1).toHavePrompt('Conflict Action Window');
                 expect(this.getChatLogs(3)).toContain('player1 plays Stay Your Hand to cancel the duel originating from Mirumoto Raitsugu');
+            });
+
+            it('should trigger when a duel targets multiple characters of yours', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.honestChallenger, this.brashSamurai],
+                    defenders: [this.mirumotoRaitsugu, this.mirumotoHitomi]
+                });
+                this.player2.clickCard(this.mirumotoHitomi);
+                this.player2.clickCard(this.honestChallenger);
+                this.player2.clickCard(this.brashSamurai);
+                this.player2.clickPrompt('Done');
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.stayYourHand);
             });
         });
     });

--- a/test/server/cards/08-MotC/KyudenKakita.spec.js
+++ b/test/server/cards/08-MotC/KyudenKakita.spec.js
@@ -9,7 +9,7 @@ describe('Kyuden Kakita', function() {
                         inPlay: ['sincere-challenger', 'solemn-scholar']
                     },
                     player2: {
-                        inPlay: ['honest-challenger']
+                        inPlay: ['honest-challenger', 'mirumoto-hitomi']
                     }
                 });
 
@@ -19,12 +19,12 @@ describe('Kyuden Kakita', function() {
                     'honest-challenger');
                 this.solemnScholar = this.player1.findCardByName(
                     'solemn-scholar');
-
+                this.mirumotoHitomi = this.player2.findCardByName('mirumoto-hitomi');
                 this.noMoreActions();
                 this.initiateConflict({
                     type: 'political',
                     attackers: [this.sincereChallenger, this.solemnScholar],
-                    defenders: [this.honestChallenger]
+                    defenders: [this.honestChallenger, this.mirumotoHitomi]
                 });
             });
 
@@ -101,6 +101,28 @@ describe('Kyuden Kakita', function() {
                 this.player1.clickCard(this.solemnScholar);
                 expect(this.player1).toHavePrompt('Conflict Action Window');
                 expect(this.solemnScholar.isHonored).toBe(true);
+            });
+
+            it('should trigger from duels where multiple characters are targeted', function () {
+                this.player2.clickCard(this.mirumotoHitomi);
+                this.player2.clickCard(this.sincereChallenger);
+                this.player2.clickCard(this.solemnScholar);
+                this.player2.clickPrompt('Done');
+                this.player1.clickPrompt('4');
+                this.player2.clickPrompt('4');
+                expect(this.player1).toHavePrompt('Mirumoto Hitomi');
+                this.player1.clickPrompt('Dishonor this character');
+                expect(this.player1).toHavePrompt('Mirumoto Hitomi');
+                this.player1.clickPrompt('Dishonor this character');
+                expect(this.solemnScholar.isDishonored).toBe(true);
+                expect(this.sincereChallenger.isDishonored).toBe(true);
+                expect(this.player1).toBeAbleToSelect('kyuden-kakita');
+                this.player1.clickCard('kyuden-kakita');
+                expect(this.player1).toBeAbleToSelect(this.solemnScholar);
+                expect(this.player1).toBeAbleToSelect(this.sincereChallenger);
+                this.player1.clickCard(this.solemnScholar);
+                expect(this.solemnScholar.isDishonored).toBe(false);
+                expect(this.sincereChallenger.isDishonored).toBe(true);
             });
         });
     });


### PR DESCRIPTION
Fixes issue #3592 
-Tests added to reproduce issue
-Stay Your Hand updated to correctly permit cancelling duels with multiple targets. 
-Tests added to Kyuden Kakita to verify that reactions are properly triggered by duels with multiple targets.