### PR TITLE
DoR - Kaiu Shihobu (using RFG - Don't merge)

### DIFF
--- a/server/game/GameActions/DynastyDeckSearchAction.ts
+++ b/server/game/GameActions/DynastyDeckSearchAction.ts
@@ -1,0 +1,118 @@
+import { PlayerAction, PlayerActionProperties } from './PlayerAction';
+import { Locations, EventNames } from '../Constants';
+import AbilityContext = require('../AbilityContext');
+import DrawCard = require('../drawcard');
+import Player = require('../player');
+
+export interface DynastyDeckSearchProperties extends PlayerActionProperties {
+    searchAmount?: number;
+    selectAmount?: number; 
+    reveal?: boolean;
+    destination?: Locations;
+    selectedCardsHandler?: (context, event, cards) => void;
+    cardCondition?: (card: DrawCard, context: AbilityContext) => boolean;
+}
+
+export class DynastyDeckSearchAction extends PlayerAction {
+    name = 'dynastyDeckSearch';
+    eventName = EventNames.OnDeckSearch;
+
+    defaultProperties: DynastyDeckSearchProperties = {
+        searchAmount: -1,
+        selectAmount: 1,
+        destination: Locations.RemovedFromGame,
+        selectedCardsHandler: null
+    };
+
+    getProperties(context: AbilityContext, additionalProperties = {}): DynastyDeckSearchProperties {
+        let properties = super.getProperties(context, additionalProperties) as DynastyDeckSearchProperties;
+        if(properties.reveal === undefined) {
+            properties.reveal = properties.cardCondition !== undefined;            
+        }
+        properties.cardCondition = properties.cardCondition || (() => true);
+        return properties;
+    }
+    
+    getEffectMessage(context: AbilityContext): [string, any[]] {
+        let properties = this.getProperties(context) as DynastyDeckSearchProperties;
+        let message = 'search their deck';
+        if(properties.searchAmount > 0) {
+            message = 'look at the top ' + (properties.searchAmount > 1 ? properties.searchAmount + ' cards' : 'card') + ' of their deck';
+        }
+        return [message, []];
+    }
+
+    canAffect(player: Player, context: AbilityContext, additionalProperties = {}): boolean {
+        let properties = this.getProperties(context, additionalProperties) as DynastyDeckSearchProperties;
+        return properties.searchAmount !== 0 && player.dynastyDeck.size() > 0 && super.canAffect(player, context);
+    }
+
+    defaultTargets(context: AbilityContext): Player[] {
+        return [context.player];
+    }
+
+    addPropertiesToEvent(event, player: Player, context: AbilityContext, additionalProperties): void {
+        let { searchAmount } = this.getProperties(context, additionalProperties) as DynastyDeckSearchProperties;        
+        super.addPropertiesToEvent(event, player, context, additionalProperties);
+        event.searchAmount = searchAmount;
+    }
+
+    eventHandler(event, additionalProperties): void {
+        let context = event.context;
+        let player = event.player;
+        let properties = this.getProperties(context, additionalProperties) as DynastyDeckSearchProperties;
+        let searchAmount = event.searchAmount > -1 ? event.searchAmount : player.dynastyDeck.size();
+        let cards = player.dynastyDeck.first(searchAmount);
+        if(event.searchAmount === -1) {
+            cards = cards.filter(card => properties.cardCondition(card, context));
+        }
+
+        let selectedCards = [];
+        this.selectCard(event, additionalProperties, cards, selectedCards);
+    }
+
+    selectCard(event, additionalProperties, cards, selectedCards) {
+        let context = event.context;
+        let player = event.player;
+        let properties = this.getProperties(context, additionalProperties) as DynastyDeckSearchProperties;
+
+        context.game.promptWithHandlerMenu(player, {
+            activePromptTitle: 'Select a card' + (properties.reveal ? ' to reveal' : ''),
+            context: context,
+            cards: cards,
+            cardCondition: properties.cardCondition,
+            choices: selectedCards.length > 0 ? ['Done'] : ['Take nothing'],
+            handlers: [() => {
+                this.handleDone(properties, context, event, selectedCards);
+            }],
+            cardHandler: card => {
+                selectedCards = selectedCards.concat(card);
+                let index = cards.indexOf(card, 0);
+                if (index > -1)
+                    cards.splice(index, 1);
+                if ((properties.selectAmount < 0 || selectedCards.length < properties.selectAmount) && cards.length > 0) {
+                    this.selectCard(event, additionalProperties, cards, selectedCards);
+                }
+                else {
+                    this.handleDone(properties, context, event, selectedCards);
+                }
+            }
+        });
+    }
+
+    handleDone(properties, context, event, selectedCards) {
+        if (properties.selectedCardsHandler == null) {
+            if (selectedCards.length > 0) {
+                context.game.addMessage('{0} selects {1}', event.player, selectedCards.map(e => e.name).join(', '))
+                selectedCards.forEach(card  => {
+                    event.player.moveCard(card, properties.destination);
+                });            
+            }
+            else
+                context.game.addMessage('{0} takes nothing', event.player);
+        }
+        else {
+            properties.selectedCardsHandler(context, event, selectedCards);
+        }
+    }
+}

--- a/server/game/GameActions/DynastyDeckSearchAction.ts
+++ b/server/game/GameActions/DynastyDeckSearchAction.ts
@@ -103,7 +103,10 @@ export class DynastyDeckSearchAction extends PlayerAction {
     handleDone(properties, context, event, selectedCards) {
         if (properties.selectedCardsHandler == null) {
             if (selectedCards.length > 0) {
-                context.game.addMessage('{0} selects {1}', event.player, selectedCards.map(e => e.name).join(', '))
+                if (properties.reveal)
+                    context.game.addMessage('{0} selects {1} and moves {2} in {3}', event.player, selectedCards.map(e => e.name).join(', '), selectedCards.length > 1 ? 'them' : 'it', properties.destination);
+                else
+                    context.game.addMessage('{0} makes a selection and moves {2} in {3}', event.player, selectedCards.map(e => e.name).join(', '), selectedCards.length > 1 ? 'them' : 'it', properties.destination);
                 selectedCards.forEach(card  => {
                     event.player.moveCard(card, properties.destination);
                 });            

--- a/server/game/GameActions/GameActions.ts
+++ b/server/game/GameActions/GameActions.ts
@@ -12,6 +12,7 @@ import { ChosenDiscardAction, ChosenDiscardProperties } from './ChosenDiscardAct
 import { ConditionalAction, ConditionalActionProperties } from './ConditionalAction';
 import { CreateTokenAction, CreateTokenProperties } from './CreateTokenAction';
 import { DeckSearchAction,  DeckSearchProperties} from './DeckSearchAction';
+import { DynastyDeckSearchAction,  DynastyDeckSearchProperties} from './DynastyDeckSearchAction';
 import { DiscardFavorAction, DiscardFavorProperties } from './DiscardFavorAction';
 import { DiscardFromPlayAction, DiscardFromPlayProperties } from './DiscardFromPlayAction';
 import { DiscardCardAction, DiscardCardProperties } from './DiscardCardAction';
@@ -110,6 +111,7 @@ const GameActions = {
     // player actions
     chosenDiscard: (propertyFactory: ChosenDiscardProperties | ((context: TriggeredAbilityContext) => ChosenDiscardProperties) = {}) => new ChosenDiscardAction(propertyFactory), // amount = 1
     deckSearch: (propertyFactory: DeckSearchProperties | ((context: TriggeredAbilityContext) => DeckSearchProperties)) => new DeckSearchAction(propertyFactory), // amount = -1, reveal = true, cardCondition = (card, context) => true
+    dynastyDeckSearch: (propertyFactory: DynastyDeckSearchProperties | ((context: TriggeredAbilityContext) => DynastyDeckSearchProperties)) => new DynastyDeckSearchAction(propertyFactory), // amount = -1, reveal = true, cardCondition = (card, context) => true
     discardAtRandom: (propertyFactory: RandomDiscardProperties | ((context: TriggeredAbilityContext) => RandomDiscardProperties) = {}) => new RandomDiscardAction(propertyFactory), // amount = 1
     draw: (propertyFactory: DrawProperties | ((context: TriggeredAbilityContext) => DrawProperties) = {}) => new DrawAction(propertyFactory), // amount = 1
     gainFate: (propertyFactory: GainFateProperties | ((context: TriggeredAbilityContext) => GainFateProperties) = {}) => new GainFateAction(propertyFactory), // amount = 1

--- a/server/game/cards/11-DoR/KaiuShihobu.js
+++ b/server/game/cards/11-DoR/KaiuShihobu.js
@@ -1,0 +1,72 @@
+const DrawCard = require('../../drawcard.js');
+const AbilityDsl = require('../../abilitydsl');
+const { Phases, Locations, CardTypes, PlayTypes, EventNames, Players } = require('../../Constants');
+
+class KaiuShihobu extends DrawCard {
+    holdingsToPlay = []
+    
+    setupCardAbilities() {
+        this.reaction({
+            title: 'Look at your dynasty deck',
+            when: { onCharacterEntersPlay: (event, context) => event.card === context.source },
+            gameAction: AbilityDsl.actions.dynastyDeckSearch({ 
+                cardCondition: card => card.type == CardTypes.Holding,
+                selectAmount: -1,
+                reveal: true,
+                selectedCardsHandler: (context, event, cards) => {
+                    if (cards.length > 0) {
+                        event.player.createAdditionalPile('shihobu');
+                        this.game.addMessage('{0} selects {1}', event.player, cards.map(e => e.name).join(', '))
+                        this.holdingsToPlay = this.holdingsToPlay.concat(cards);
+                        cards.forEach(card => {
+                            event.player.moveCard(card, Locations.RemovedFromGame);
+                        });
+                    }
+                    else
+                        this.game.addMessage('{0} selects no holdings', event.player);
+                    event.player.shuffleDynastyDeck();
+                }
+            })         
+        });
+
+        this.action({
+            title: 'Put a holding in a province',
+            targets: {
+                first: {
+                    activePromptTitle: 'Choose a holding',
+                    cardType: CardTypes.Holding,
+                    controller: Players.Self,
+                    location: Locations.RemovedFromGame,
+                    cardCondition: card => this.holdingsToPlay.includes(card)
+                },
+                second: {
+                    activePromptTitle: 'Choose an unbroken province',
+                    dependsOn: 'first',
+                    optional: false,
+                    cardType: CardTypes.Province,
+                    location: Locations.Provinces,
+                    controller: Players.Self,
+                    cardCondition: card => card.location !== Locations.StrongholdProvince && !card.isBroken
+                },
+            },
+            handler: context => {
+                let holding = context.targets.first;
+                let province = context.targets.second;
+
+                let cards = context.player.getDynastyCardsInProvince(province.location);
+                //Leaving this here since it sounds like she's going to be errata-ed to face up
+                // this.game.addMessage('{0} discards {1}, replacing it with {2}', context.player, cards.map(e => e.name).join(', '), holding);
+                this.game.addMessage('{0} discards {1}, replacing it with a facedown holding', context.player, cards.map(e => e.name).join(', '));
+                context.player.moveCard(holding, province.location);
+                holding.facedown = true;
+                cards.forEach(card => {
+                    context.player.moveCard(card, Locations.DynastyDiscardPile);
+                });
+            }
+        });
+    }
+}
+
+KaiuShihobu.id = 'kaiu-shihobu';
+
+module.exports = KaiuShihobu;

--- a/server/game/cards/11-DoR/KaiuShihobu.js
+++ b/server/game/cards/11-DoR/KaiuShihobu.js
@@ -1,6 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 const AbilityDsl = require('../../abilitydsl');
-const { Phases, Locations, CardTypes, PlayTypes, EventNames, Players } = require('../../Constants');
+const { Locations, CardTypes, Players } = require('../../Constants');
 
 class KaiuShihobu extends DrawCard {
     PILENAME = 'shihobu'
@@ -9,15 +9,16 @@ class KaiuShihobu extends DrawCard {
         this.reaction({
             title: 'Look at your dynasty deck',
             when: { onCharacterEntersPlay: (event, context) => event.card === context.source },
-            gameAction: AbilityDsl.actions.dynastyDeckSearch({ 
-                cardCondition: card => card.type == CardTypes.Holding,
+            gameAction: AbilityDsl.actions.dynastyDeckSearch({
+                cardCondition: card => card.type === CardTypes.Holding,
                 selectAmount: -1,
                 reveal: true,
                 selectedCardsHandler: (context, event, cards) => {
-                    if (cards.length > 0) {
-                        if (!(this.PILENAME in event.player.additionalPiles))
+                    if(cards.length > 0) {
+                        if(!(this.PILENAME in event.player.additionalPiles)) {
                             event.player.createAdditionalPile(this.PILENAME);
-                        this.game.addMessage('{0} selects {1}', event.player, cards.map(e => e.name).join(', '))
+                        }
+                        this.game.addMessage('{0} selects {1}', event.player, cards.map(e => e.name).sort().join(', '));
                         event.player.additionalPiles[this.PILENAME].cards = event.player.additionalPiles[this.PILENAME].cards.concat(cards);
                         cards.forEach(card => {
                             event.player.moveCard(card, Locations.RemovedFromGame);
@@ -27,16 +28,16 @@ class KaiuShihobu extends DrawCard {
                                 },
                                 match: card,
                                 effect: [
-                                    AbilityDsl.effects.hideWhenFaceUp(),
+                                    AbilityDsl.effects.hideWhenFaceUp()
                                 ]
                             }));
                         });
-                    }
-                    else
+                    } else {
                         this.game.addMessage('{0} selects no holdings', event.player);
+                    }
                     event.player.shuffleDynastyDeck();
                 }
-            })         
+            })
         });
 
         this.action({
@@ -57,16 +58,13 @@ class KaiuShihobu extends DrawCard {
                     location: Locations.Provinces,
                     controller: Players.Self,
                     cardCondition: card => card.location !== Locations.StrongholdProvince && !card.isBroken
-                },
+                }
             },
             handler: context => {
                 let holding = context.targets.first;
                 let province = context.targets.second;
 
                 let cards = context.player.getDynastyCardsInProvince(province.location);
-                //Leaving this here since it sounds like she's going to be errata-ed to face up
-                // this.game.addMessage('{0} discards {1}, replacing it with {2}', context.player, cards.map(e => e.name).join(', '), holding);
-                // this.game.addMessage('{0} uses {1} to discard {2}, replacing it with a facedown holding', context.player, context.source, cards.map(e => e.name).join(', '));
                 context.player.moveCard(holding, province.location);
                 holding.facedown = true;
                 cards.forEach(card => {
@@ -74,7 +72,7 @@ class KaiuShihobu extends DrawCard {
                 });
             },
             effect: 'discard {1}, replacing it with a facedown holding',
-            effectArgs: context => context.player.getDynastyCardsInProvince(context.targets.second.location).map(e => e.name).join(', ')
+            effectArgs: context => context.player.getDynastyCardsInProvince(context.targets.second.location).map(e => e.name).sort().join(', ')
         });
     }
 }

--- a/server/game/cards/11-DoR/KaiuShihobu.js
+++ b/server/game/cards/11-DoR/KaiuShihobu.js
@@ -15,11 +15,22 @@ class KaiuShihobu extends DrawCard {
                 reveal: true,
                 selectedCardsHandler: (context, event, cards) => {
                     if (cards.length > 0) {
-                        event.player.createAdditionalPile('shihobu');
+                        if (!('shihobu' in event.player.additionalPiles))
+                            event.player.createAdditionalPile('shihobu');
                         this.game.addMessage('{0} selects {1}', event.player, cards.map(e => e.name).join(', '))
-                        this.holdingsToPlay = this.holdingsToPlay.concat(cards);
+                        event.player.additionalPiles['shihobu'].cards = event.player.additionalPiles['shihobu'].cards.concat(cards);
+                        // this.holdingsToPlay = this.holdingsToPlay.concat(cards);
                         cards.forEach(card => {
                             event.player.moveCard(card, Locations.RemovedFromGame);
+                            card.lastingEffect(ability => ({
+                                until: {
+                                    onCardMoved: event => event.card === card && event.originalLocation === Locations.RemovedFromGame
+                                },
+                                match: card,
+                                effect: [
+                                    ability.effects.hideWhenFaceUp(),
+                                ]
+                            }));
                         });
                     }
                     else
@@ -37,7 +48,7 @@ class KaiuShihobu extends DrawCard {
                     cardType: CardTypes.Holding,
                     controller: Players.Self,
                     location: Locations.RemovedFromGame,
-                    cardCondition: card => this.holdingsToPlay.includes(card)
+                    cardCondition: (card, context) => context.player.additionalPiles['shihobu'].cards.includes(card)//this.holdingsToPlay.includes(card)
                 },
                 second: {
                     activePromptTitle: 'Choose an unbroken province',

--- a/server/game/cards/11-DoR/KaiuShihobu.js
+++ b/server/game/cards/11-DoR/KaiuShihobu.js
@@ -1,6 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 const AbilityDsl = require('../../abilitydsl');
-const { Locations, CardTypes, Players } = require('../../Constants');
+const { Locations, CardTypes, Players, TargetModes } = require('../../Constants');
 
 class KaiuShihobu extends DrawCard {
     PILENAME = 'shihobu'
@@ -11,7 +11,7 @@ class KaiuShihobu extends DrawCard {
             when: { onCharacterEntersPlay: (event, context) => event.card === context.source },
             gameAction: AbilityDsl.actions.dynastyDeckSearch({
                 cardCondition: card => card.type === CardTypes.Holding,
-                selectAmount: -1,
+                targetMode: TargetModes.Unlimited,
                 reveal: true,
                 selectedCardsHandler: (context, event, cards) => {
                     if(cards.length > 0) {

--- a/test/server/cards/11-DoR/KaiuShihobu.spec.js
+++ b/test/server/cards/11-DoR/KaiuShihobu.spec.js
@@ -1,0 +1,244 @@
+describe('Kaiu Shihobu', function() {
+    integration(function() {
+        describe('Kaiu Shihobu\'s abilities', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    phase: 'dynasty',
+                    player1: {
+                        dynastyDiscard: ['imperial-storehouse', 'favorable-ground', 'ancestral-armory', 'ancestral-shrine', 'hida-kisada', 'kaiu-shihobu', 'artisan-academy', 'forgotten-library', 'hall-of-victories'],
+                        dynastyDeckSize: 4
+                    }
+                });
+
+                this.storehouse = this.player1.findCardByName('imperial-storehouse');
+                this.favorableGround = this.player1.findCardByName('favorable-ground');
+                this.ancestralArmory = this.player1.findCardByName('ancestral-armory');
+                this.ancestralShrine = this.player1.findCardByName('ancestral-shrine');
+                this.kisada = this.player1.findCardByName('hida-kisada');
+                this.shamefulDisplay = this.player1.findCardByName('shameful-display', 'province 1');
+
+                this.artisanAcademy = this.player1.findCardByName('artisan-academy');
+                this.forgottenLibrary = this.player1.findCardByName('forgotten-library');
+                this.hallOfVictories = this.player1.findCardByName('hall-of-victories');
+
+                this.kaiuShihobu = this.player1.placeCardInProvince('kaiu-shihobu');
+
+                this.player1.moveCard(this.storehouse, 'dynasty deck');
+                this.player1.moveCard(this.favorableGround, 'dynasty deck');
+                this.player1.moveCard(this.ancestralArmory, 'dynasty deck');
+                this.player1.moveCard(this.ancestralShrine, 'dynasty deck');
+                this.player1.moveCard(this.kisada, 'dynasty deck');
+            });
+
+            it('should trigger when played in dynasty', function() {
+                this.player1.clickCard(this.kaiuShihobu);
+                this.player1.clickPrompt('0');
+                expect(this.player1).toBeAbleToSelect(this.kaiuShihobu);
+            });
+
+            it('should allow you to select holdings from your dynasty deck when triggered', function() {
+                this.player1.clickCard(this.kaiuShihobu);
+                this.player1.clickPrompt('0');
+                expect(this.player1).toBeAbleToSelect(this.kaiuShihobu);
+                this.player1.clickCard(this.kaiuShihobu);
+
+                expect(this.player1).toHavePromptButton('Imperial Storehouse');
+                expect(this.player1).toHavePromptButton('Favorable Ground');
+                expect(this.player1).toHavePromptButton('Ancestral Armory');
+                expect(this.player1).toHavePromptButton('Ancestral Shrine');
+                expect(this.player1).not.toHavePromptButton('Hida Kisada');
+                expect(this.player1).toHavePromptButton('Take nothing');
+
+                this.player1.clickPrompt('Imperial Storehouse');
+                expect(this.player1).not.toHavePromptButton('Imperial Storehouse');
+                expect(this.player1).not.toHavePromptButton('Take nothing');
+                expect(this.player1).toHavePromptButton('Done');
+                this.player1.clickPrompt('Favorable Ground');
+                this.player1.clickPrompt('Ancestral Armory');
+                this.player1.clickPrompt('Done');
+
+                expect(this.storehouse.location).toBe('removed from game');
+                expect(this.favorableGround.location).toBe('removed from game');
+                expect(this.ancestralArmory.location).toBe('removed from game');
+                expect(this.ancestralShrine.location).not.toBe('removed from game');
+
+                expect(this.getChatLogs(2)).toContain('player1 selects Ancestral Armory, Favorable Ground, Imperial Storehouse');
+                expect(this.getChatLogs(1)).toContain('player1 is shuffling their dynasty deck');
+            });
+
+            it('removed from game holdings should be hidden to player2', function() {
+                this.player1.clickCard(this.kaiuShihobu);
+                this.player1.clickPrompt('0');
+                expect(this.player1).toBeAbleToSelect(this.kaiuShihobu);
+                this.player1.clickCard(this.kaiuShihobu);
+
+                this.player1.clickPrompt('Imperial Storehouse');
+                this.player1.clickPrompt('Favorable Ground');
+                this.player1.clickPrompt('Ancestral Armory');
+                this.player1.clickPrompt('Done');
+
+                expect(this.storehouse.location).toBe('removed from game');
+                expect(this.favorableGround.location).toBe('removed from game');
+                expect(this.ancestralArmory.location).toBe('removed from game');
+                expect(this.ancestralShrine.location).not.toBe('removed from game');
+
+                expect(this.storehouse.anyEffect('hideWhenFaceUp')).toBe(true);
+                expect(this.favorableGround.anyEffect('hideWhenFaceUp')).toBe(true);
+                expect(this.ancestralArmory.anyEffect('hideWhenFaceUp')).toBe(true);
+            });
+
+            it('should allow you to put into play a holding that has been removed from game via Shihobu', function() {
+                this.player1.clickCard(this.kaiuShihobu);
+                this.player1.clickPrompt('0');
+                expect(this.player1).toBeAbleToSelect(this.kaiuShihobu);
+                this.player1.clickCard(this.kaiuShihobu);
+
+                this.player1.clickPrompt('Imperial Storehouse');
+                this.player1.clickPrompt('Favorable Ground');
+                this.player1.clickPrompt('Ancestral Armory');
+                this.player1.clickPrompt('Done');
+
+                expect(this.storehouse.location).toBe('removed from game');
+                expect(this.favorableGround.location).toBe('removed from game');
+                expect(this.ancestralArmory.location).toBe('removed from game');
+                expect(this.ancestralShrine.location).not.toBe('removed from game');
+
+                this.player2.pass();
+                this.player1.clickCard(this.kaiuShihobu);
+                expect(this.player1).toBeAbleToSelect(this.storehouse);
+                expect(this.player1).toBeAbleToSelect(this.favorableGround);
+                expect(this.player1).toBeAbleToSelect(this.ancestralArmory);
+
+                this.currentCard = this.player1.player.getDynastyCardInProvince('province 1');
+
+                this.player1.clickCard(this.storehouse);
+                this.player1.clickCard(this.shamefulDisplay);
+                expect(this.storehouse.location).toBe('province 1');
+                expect(this.storehouse.facedown).toBe(true);
+
+                expect(this.getChatLogs(1)).toContain('player1 uses Kaiu Shihobu to discard ' + this.currentCard.name + ', replacing it with a facedown holding');
+            });
+        });
+
+        describe('Kaiu Shihobu\'s abilities (edge cases)', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    phase: 'dynasty',
+                    player1: {
+                        dynastyDiscard: ['imperial-storehouse', 'favorable-ground', 'ancestral-armory', 'ancestral-shrine', 'hida-kisada', 'kaiu-shihobu', 'artisan-academy', 'forgotten-library', 'hall-of-victories', 'kaiu-shihobu'],
+                        inPlay: ['kitsuki-kagi'],
+                        hand: ['forebearer-s-echoes'],
+                        dynastyDeckSize: 4
+                    },
+                    player2: {
+                        inPlay: ['doji-kuwanan'],
+                        hand: ['way-of-the-crane', 'way-of-the-scorpion', 'noble-sacrifice']
+                    }
+                });
+
+                this.storehouse = this.player1.findCardByName('imperial-storehouse');
+                this.favorableGround = this.player1.findCardByName('favorable-ground');
+                this.ancestralArmory = this.player1.findCardByName('ancestral-armory');
+                this.ancestralShrine = this.player1.findCardByName('ancestral-shrine');
+                this.kisada = this.player1.findCardByName('hida-kisada');
+                this.shamefulDisplay = this.player1.findCardByName('shameful-display', 'province 1');
+
+                this.artisanAcademy = this.player1.findCardByName('artisan-academy');
+                this.forgottenLibrary = this.player1.findCardByName('forgotten-library');
+                this.hallOfVictories = this.player1.findCardByName('hall-of-victories');
+
+                this.kaiuShihobu = this.player1.filterCardsByName('kaiu-shihobu')[0];
+                this.kaiuShihobu2 = this.player1.filterCardsByName('kaiu-shihobu')[1];
+                this.player1.placeCardInProvince(this.kaiuShihobu);
+                this.kagi = this.player1.findCardByName('kitsuki-kagi');
+                this.echoes = this.player1.findCardByName('forebearer-s-echoes');
+
+                this.kuwanan = this.player2.findCardByName('doji-kuwanan');
+                this.crane = this.player2.findCardByName('way-of-the-crane');
+                this.scorpion = this.player2.findCardByName('way-of-the-scorpion');
+                this.nobleSac = this.player2.findCardByName('noble-sacrifice');
+
+                this.player1.moveCard(this.storehouse, 'dynasty deck');
+                this.player1.moveCard(this.favorableGround, 'dynasty deck');
+                this.player1.moveCard(this.ancestralArmory, 'dynasty deck');
+                this.player1.moveCard(this.ancestralShrine, 'dynasty deck');
+                this.player1.moveCard(this.kisada, 'dynasty deck');
+
+                this.player1.clickCard(this.kaiuShihobu);
+                this.player1.clickPrompt('0');
+                this.player1.clickCard(this.kaiuShihobu);
+
+                this.player1.clickPrompt('Imperial Storehouse');
+                this.player1.clickPrompt('Favorable Ground');
+                this.player1.clickPrompt('Ancestral Armory');
+                this.player1.clickPrompt('Done');
+
+                this.advancePhases('conflict');
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.kagi, this.kaiuShihobu],
+                    defenders: [this.kuwanan]
+                });
+            });
+
+            it('should not allow you to put into play a holding that has been removed from game via another card', function() {
+                this.noMoreActions();
+                expect(this.player1).toBeAbleToSelect(this.kagi);
+                this.player1.clickCard(this.kagi);
+                expect(this.player1).toBeAbleToSelect(this.artisanAcademy);
+                expect(this.player1).toBeAbleToSelect(this.hallOfVictories);
+                expect(this.player1).toBeAbleToSelect(this.forgottenLibrary);
+
+                this.player1.clickCard(this.artisanAcademy);
+                this.player1.clickCard(this.hallOfVictories);
+                this.player1.clickCard(this.forgottenLibrary);
+
+                expect(this.artisanAcademy.location).toBe('removed from game');
+                expect(this.hallOfVictories.location).toBe('removed from game');
+                expect(this.forgottenLibrary.location).toBe('removed from game');
+
+                this.player1.clickPrompt('Don\'t Resolve');
+                expect(this.player1).toHavePrompt('Action Window');
+
+                this.player1.clickCard(this.kaiuShihobu);
+                expect(this.player1).toBeAbleToSelect(this.storehouse);
+                expect(this.player1).toBeAbleToSelect(this.favorableGround);
+                expect(this.player1).toBeAbleToSelect(this.ancestralArmory);
+                expect(this.player1).not.toBeAbleToSelect(this.artisanAcademy);
+                expect(this.player1).not.toBeAbleToSelect(this.hallOfVictories);
+                expect(this.player1).not.toBeAbleToSelect(this.forgottenLibrary);
+            });
+
+            it('should work if a new Shihobu comes into play', function() {
+                this.player1.moveCard(this.artisanAcademy, 'dynasty deck');
+                this.player1.moveCard(this.hallOfVictories, 'dynasty deck');
+                this.player1.moveCard(this.forgottenLibrary, 'dynasty deck');
+
+                this.player2.clickCard(this.crane);
+                this.player2.clickCard(this.kuwanan);
+                this.player1.pass();
+                this.player2.clickCard(this.scorpion);
+                this.player2.clickCard(this.kaiuShihobu);
+                this.player1.pass();
+                this.player2.clickCard(this.nobleSac);
+                this.player2.clickCard(this.kaiuShihobu);
+                this.player2.clickCard(this.kuwanan);
+
+                this.player1.clickCard(this.echoes);
+                this.player1.clickCard(this.kaiuShihobu2);
+                this.player1.clickCard(this.kaiuShihobu2);
+                this.player1.clickPrompt('Artisan Academy');
+                this.player1.clickPrompt('Done');
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.kaiuShihobu2);
+                expect(this.player1).toBeAbleToSelect(this.storehouse);
+                expect(this.player1).toBeAbleToSelect(this.favorableGround);
+                expect(this.player1).toBeAbleToSelect(this.ancestralArmory);
+                expect(this.player1).toBeAbleToSelect(this.artisanAcademy);
+            });
+        });
+    });
+});

--- a/test/server/cards/11-DoR/KaiuShihobu.spec.js
+++ b/test/server/cards/11-DoR/KaiuShihobu.spec.js
@@ -118,6 +118,42 @@ describe('Kaiu Shihobu', function() {
 
                 expect(this.getChatLogs(1)).toContain('player1 uses Kaiu Shihobu to discard ' + this.currentCard.name + ', replacing it with a facedown holding');
             });
+
+            it('should discard multiple cards if multiple cards are in the province', function() {
+                this.player1.clickCard(this.kaiuShihobu);
+                this.player1.clickPrompt('0');
+                expect(this.player1).toBeAbleToSelect(this.kaiuShihobu);
+                this.player1.clickCard(this.kaiuShihobu);
+
+                this.player1.clickPrompt('Imperial Storehouse');
+                this.player1.clickPrompt('Favorable Ground');
+                this.player1.clickPrompt('Ancestral Armory');
+                this.player1.clickPrompt('Done');
+
+                expect(this.storehouse.location).toBe('removed from game');
+                expect(this.favorableGround.location).toBe('removed from game');
+                expect(this.ancestralArmory.location).toBe('removed from game');
+                expect(this.ancestralShrine.location).not.toBe('removed from game');
+
+                this.player1.moveCard(this.artisanAcademy, 'province 1');
+                this.player1.moveCard(this.hallOfVictories, 'province 1');
+                this.player1.moveCard(this.forgottenLibrary, 'province 1');
+
+                this.player2.pass();
+                this.player1.clickCard(this.kaiuShihobu);
+                expect(this.player1).toBeAbleToSelect(this.storehouse);
+                expect(this.player1).toBeAbleToSelect(this.favorableGround);
+                expect(this.player1).toBeAbleToSelect(this.ancestralArmory);
+
+                this.currentCards = this.player1.player.getDynastyCardsInProvince('province 1');
+
+                this.player1.clickCard(this.storehouse);
+                this.player1.clickCard(this.shamefulDisplay);
+                expect(this.storehouse.location).toBe('province 1');
+                expect(this.storehouse.facedown).toBe(true);
+
+                expect(this.getChatLogs(1)).toContain('player1 uses Kaiu Shihobu to discard ' + this.currentCards.map(e => e.name).sort().join(', ') + ', replacing it with a facedown holding');
+            });
         });
 
         describe('Kaiu Shihobu\'s abilities (edge cases)', function() {


### PR DESCRIPTION
Closes #3661

Uses Removed from Game, and the card selector menu is a bit big.  But works decently well.  Holdings removed from game are revealed (dumped in the chat log), but are facedown in the pile for the opponent.

Going to work on adding support for cards under other cards, using the following as reference:
UI - https://github.com/throneteki/throneteki-client/pull/23/files
Backend - https://github.com/throneteki/throneteki/pull/2078/files
(For Reference: https://github.com/throneteki/throneteki/blob/master/server/game/cards/11.2-TMoW/Meereen.js)