### PR TITLE
Bug Fix - Gamenode crash during targeting if no opponent

### DIFF
--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -38,7 +38,8 @@ class BaseCardSelector {
         }
         let attachments = context.player.cardsInPlay.reduce((array, card) => array.concat(card.attachments.toArray()), []);
         let allProvinceAttachments = context.player.getProvinces().reduce((array, card) => array.concat(card.attachments.toArray()), []);
-        allProvinceAttachments = allProvinceAttachments.concat(context.player.opponent.getProvinces().reduce((array, card) => array.concat(card.attachments.toArray()), []));
+        if (context.player.opponent)
+            allProvinceAttachments = allProvinceAttachments.concat(context.player.opponent.getProvinces().reduce((array, card) => array.concat(card.attachments.toArray()), []));
         attachments = attachments.concat(allProvinceAttachments);
 
         if(context.source.game.rings) {

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -38,8 +38,9 @@ class BaseCardSelector {
         }
         let attachments = context.player.cardsInPlay.reduce((array, card) => array.concat(card.attachments.toArray()), []);
         let allProvinceAttachments = context.player.getProvinces().reduce((array, card) => array.concat(card.attachments.toArray()), []);
-        if (context.player.opponent)
+        if(context.player.opponent) {
             allProvinceAttachments = allProvinceAttachments.concat(context.player.opponent.getProvinces().reduce((array, card) => array.concat(card.attachments.toArray()), []));
+        }
         attachments = attachments.concat(allProvinceAttachments);
 
         if(context.source.game.rings) {


### PR DESCRIPTION
The new check that lets you target Total Warfare scans your provinces & your opponent's provinces for attachments.  If your opponent doesn't exist, this crashes the game node.

Introduced in https://github.com/gryffon/ringteki/pull/3709