### PR TITLE
Added null checks to Seventh Tower

### DIFF
--- a/server/game/cards/11-DoR/SeventhTower.js
+++ b/server/game/cards/11-DoR/SeventhTower.js
@@ -8,9 +8,12 @@ class SeventhTower extends DrawCard {
             title: 'Resolve the ring effect',
             when: {
                 afterConflict: (event, context) => {
-                    let cards = context.player.getDynastyCardsInProvince(event.conflict.conflictProvince.location);
-                    return cards.some((card) => !card.facedown && card.type === CardTypes.Holding && card.hasTrait('kaiu-wall'))
-                            && context.player.isDefendingPlayer() && event.conflict.winner === context.player;
+                    if(event && event.conflict && event.conflict.conflictProvince && event.conflict.conflictProvince.location) {
+                        let cards = context.player.getDynastyCardsInProvince(event.conflict.conflictProvince.location);
+                        return cards.some((card) => !card.facedown && card.type === CardTypes.Holding && card.hasTrait('kaiu-wall'))
+                                && context.player.isDefendingPlayer() && event.conflict.winner === context.player;
+                    }
+                    return false;
                 }
             },
             gameAction: AbilityDsl.actions.resolveConflictRing()


### PR DESCRIPTION
Fixing error report

2019-12-13T22:59:13.603Z - error:  message=Cannot read property 'location' of null, stack=TypeError: Cannot read property 'location' of null
    at afterConflict (/server/game/cards/11-DoR/SeventhTower.js:11:106)

